### PR TITLE
PHP7: Fixing errors when building on WIndows 

### DIFF
--- a/config.w32
+++ b/config.w32
@@ -59,7 +59,7 @@ if(PHP_SOLR != 'no')
 					'php_solr_collapse_function.c'
 			);
 
-		ADD_FLAG('CFLAGS_SOLR', '/D CURL_STATICLIB /D LIBXML_STATICLIB');
+		ADD_FLAG('CFLAGS_SOLR', '/I"' + configure_module_dirname + '" /D CURL_STATICLIB /D LIBXML_STATICLIB');
 		AC_DEFINE('HAVE_SOLR', 1, 'Solr support');
 
 		if (!PHP_SOLR_SHARED) {

--- a/solr_functions_helpers.c
+++ b/solr_functions_helpers.c
@@ -136,17 +136,17 @@ PHP_SOLR_API void solr_query_register_class_constants(zend_class_entry *ce TSRML
 /** FUNCTIONS FOR REFERENCE COUNT MANAGEMENT                                 **/
 /** ************************************************************************ **/
 
-/** {{{ void solr_zval_add_ref(zval **p) */
-PHP_SOLR_API void solr_zval_add_ref(zval **p)
+/** {{{ void solr_zval_add_ref(zval *p) */
+PHP_SOLR_API void solr_zval_add_ref(zval *p)
 {
-	Z_ADDREF_PP(p);
+	Z_ADDREF_P(p);
 }
 /* }}} */
 
-/** {{{ void solr_zval_minus_ref(zval **p) */
-PHP_SOLR_API void solr_zval_minus_ref(zval **p)
+/** {{{ void solr_zval_minus_ref(zval *p) */
+PHP_SOLR_API void solr_zval_minus_ref(zval *p)
 {
-	Z_DELREF_PP(p);
+	Z_DELREF_P(p);
 }
 /* }}} */
 

--- a/solr_functions_params.c
+++ b/solr_functions_params.c
@@ -654,7 +654,7 @@ PHP_SOLR_API void solr_normal_param_value_fetch(solr_param_t *solr_param, solr_s
 
 			solr_string_appends(buffer, url_encoded_param_value->val, url_encoded_param_value->len);
 
-			solr_string_release(url_encoded_param_value);
+			solr_string_free(url_encoded_param_value);
 
 			solr_string_appendc(buffer, glue);
 
@@ -756,7 +756,7 @@ PHP_SOLR_API void solr_arg_list_param_value_fetch(solr_param_t *solr_param, solr
 
 	solr_string_appends(buffer, url_encoded_list->val, url_encoded_list->len);
 
-	solr_string_release(url_encoded_list);
+	solr_string_free(url_encoded_list);
 
 	url_encoded_list = NULL;
 


### PR DESCRIPTION
Some fixes for errors I encountered wheb building on Windows (VC14).
I do not know why php_solr_bc_macros.h did not  fix Z_ADDREF_PP and Z_DELREF_PP, but I ran into a fatal error:

>ext\solr\solr_functions_helpers.c(142): warning C4013: 'Z_ADDREF_PP' undefined; assuming extern returning int
>ext\solr\solr_functions_helpers.c(149): warning C4013: 'Z_DELREF_PP' undefined; assuming extern returning int

...

>   Creating library C:\php-sdk\php70dev\Release\php_solr.lib and object C:\php-sdk\php70dev\Release\php_solr.exp
>solr_functions_helpers.obj : error LNK2019: unresolved external symbol _Z_ADDREF_PP referenced in function _solr_zval_add_ref
>solr_functions_helpers.obj : error LNK2019: unresolved external symbol _Z_DELREF_PP referenced in function _solr_zval_minus_ref
