### PR TITLE
Enable gzip encoding if server supports it

### DIFF
--- a/src/php5/solr_functions_client.c
+++ b/src/php5/solr_functions_client.c
@@ -87,6 +87,7 @@ static void solr_set_initial_curl_handle_options(solr_curl_t **sch_ptr, solr_cli
 	curl_easy_setopt(sch->curl_handle, CURLOPT_FOLLOWLOCATION, 1L);
 	curl_easy_setopt(sch->curl_handle, CURLOPT_MAXREDIRS, 16L); /* prevent infinite redirects  */
 	curl_easy_setopt(sch->curl_handle, CURLOPT_UNRESTRICTED_AUTH, 0L);
+	curl_easy_setopt(sch->curl_handle, CURLOPT_ACCEPT_ENCODING, "");
 
 #ifdef ZTS
 	curl_easy_setopt(sch->curl_handle, CURLOPT_NOSIGNAL, 1L); /** Needed in multi-threaded environments **/

--- a/src/php7/solr_functions_client.c
+++ b/src/php7/solr_functions_client.c
@@ -87,6 +87,7 @@ static void solr_set_initial_curl_handle_options(solr_curl_t **sch_ptr, solr_cli
 	curl_easy_setopt(sch->curl_handle, CURLOPT_FOLLOWLOCATION, 1L);
 	curl_easy_setopt(sch->curl_handle, CURLOPT_MAXREDIRS, 16L); /* prevent infinite redirects  */
 	curl_easy_setopt(sch->curl_handle, CURLOPT_UNRESTRICTED_AUTH, 0L);
+	curl_easy_setopt(sch->curl_handle, CURLOPT_ACCEPT_ENCODING, "");
 
 #ifdef ZTS
 	curl_easy_setopt(sch->curl_handle, CURLOPT_NOSIGNAL, 1L); /** Needed in multi-threaded environments **/

--- a/tests/013.solrclient_getByIds.phpt
+++ b/tests/013.solrclient_getByIds.phpt
@@ -50,6 +50,7 @@ Exception 4000: Invalid id at position 1
 
 - Headers start
 Accept-Charset: utf-8
+Accept-Encoding: deflate, gzip
 Accept: */*
 Authorization: Basic YWRtaW46Y2hhbmdlaXQ=
 Connection: keep-alive

--- a/tests/019.solrclient_getdebug.phpt
+++ b/tests/019.solrclient_getdebug.phpt
@@ -42,6 +42,7 @@ foreach ( $lines as $line) {
 ?>
 --EXPECTF--
 Accept-Charset: utf-8
+Accept-Encoding: deflate, gzip
 Accept: */*
 Authorization: Basic YWRtaW46Y2hhbmdlaXQ=
 Connected to %s (%s) port 8983 (#0)


### PR DESCRIPTION
This patch enables gzip encoding if the solr server supports it.