### PR TITLE
Replace obsolete AC_TRY_COMPILE with AC_COMPILE_IFELSE

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -116,13 +116,13 @@ if test "$PHP_SOLR" != "no"; then
     
     AC_MSG_CHECKING(PHP version)
     
-    AC_TRY_COMPILE([
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
     #include <php_version.h>
-    ],[
+    ]], [[
 #if PHP_MAJOR_VERSION > 5
 #error PHP > 5
 #endif
-    ],[
+    ]])],[
     subdir=src/php5
     AC_MSG_RESULT([PHP 5])
     ],[


### PR DESCRIPTION
Hello, Autoconf made several macros obsolete including the `AC_TRY_COMPILE` in 2000:
http://git.savannah.gnu.org/cgit/autoconf.git/tree/ChangeLog.2

It should be replaced with the current `AC_COMPILE_IFELSE` instead.

PHP 5.3 required Autoconf 2.13 or newer, since PHP 5.4 the autoconf 2.59 or newer was required, and since PHP 7.2, autoconf 2.64 or newer is required.

It is fairly safe to upgrade and take the recommendation advice of autoconf upgrade manual since the upgrade should be compatible at least with PHP versions 5.4 and up, on some systems even with PHP 5.3.

Reference docs:
- https://www.gnu.org/software/autoconf/manual/autoconf-2.69/html_node/Obsolete-Macros.html

Thank you for considering merging this or checking it out. In case of doubts or questions just ask...
