### PR TITLE
Remove HAVE_STRING_H, HAVE_STDARG_H, and HAVE_STDLIB_H

### DIFF
--- a/pecl-compat/compat.h
+++ b/pecl-compat/compat.h
@@ -46,9 +46,7 @@
 #	include "config.h"
 #endif
 
-#if HAVE_STRING_H
-#	include <string.h>
-#endif
+#include <string.h>
 
 #ifdef HAVE_SYS_TYPES_H
 #	include <sys/types.h>
@@ -67,13 +65,8 @@
 #	include <sys/resource.h>
 #endif
 
-#ifdef HAVE_STDARG_H
 #include <stdarg.h>
-#endif
-
-#ifdef HAVE_STDLIB_H
-#	include <stdlib.h>
-#endif
+#include <stdlib.h>
 
 #ifdef HAVE_UNISTD_H
 #	include <unistd.h>


### PR DESCRIPTION
These symbols are defined by the build system to check the presence of the standard C89 headers. Since C89 is really widely adopted across systems already, these checks are obsolete today and not needed.

http://port70.net/~nsz/c/c89/c89-draft.html#4.1.2

Some of these checks are also removed since PHP-7.4.