### PR TITLE
Fixes regression added while fixing Bug #72740

### DIFF
--- a/src/php5/solr_functions_params.c
+++ b/src/php5/solr_functions_params.c
@@ -713,7 +713,7 @@ PHP_SOLR_API void solr_arg_list_param_value_fetch(solr_param_t *solr_param, solr
 	{
 		solr_string_append_solr_string(&tmp_buffer, &(current_ptr->contents.arg_list.value));
 
-		if (current_ptr->contents.arg_list.delimiter_override) {
+		if (current_ptr->contents.arg_list.delimiter_override && *current_ptr->contents.arg_list.delimiter_override) {
 		    solr_string_appendc(&tmp_buffer, *current_ptr->contents.arg_list.delimiter_override);
 		} else {
 		    solr_string_appendc(&tmp_buffer, separator);
@@ -730,7 +730,7 @@ PHP_SOLR_API void solr_arg_list_param_value_fetch(solr_param_t *solr_param, solr
 
 	solr_string_append_solr_string(&tmp_buffer, &(current_ptr->contents.arg_list.value));
 
-	if (current_ptr->contents.arg_list.delimiter_override) {
+	if (current_ptr->contents.arg_list.delimiter_override && *current_ptr->contents.arg_list.delimiter_override) {
 	    solr_string_appendc(&tmp_buffer, *current_ptr->contents.arg_list.delimiter_override);
 	} else {
 	    solr_string_appendc(&tmp_buffer, separator);

--- a/src/php7/solr_functions_params.c
+++ b/src/php7/solr_functions_params.c
@@ -700,7 +700,7 @@ PHP_SOLR_API void solr_arg_list_param_value_fetch(solr_param_t *solr_param, solr
 	{
 		solr_string_append_solr_string(&tmp_buffer, &(current_ptr->contents.arg_list.value));
 
-		if (current_ptr->contents.arg_list.delimiter_override) {
+		if (current_ptr->contents.arg_list.delimiter_override && *current_ptr->contents.arg_list.delimiter_override) {
 		    solr_string_appendc(&tmp_buffer, *current_ptr->contents.arg_list.delimiter_override);
 		} else {
 		    solr_string_appendc(&tmp_buffer, separator);
@@ -717,7 +717,7 @@ PHP_SOLR_API void solr_arg_list_param_value_fetch(solr_param_t *solr_param, solr
 
 	solr_string_append_solr_string(&tmp_buffer, &(current_ptr->contents.arg_list.value));
 
-	if (current_ptr->contents.arg_list.delimiter_override) {
+	if (current_ptr->contents.arg_list.delimiter_override && *current_ptr->contents.arg_list.delimiter_override) {
 	    solr_string_appendc(&tmp_buffer, *current_ptr->contents.arg_list.delimiter_override);
 	} else {
 	    solr_string_appendc(&tmp_buffer, separator);

--- a/tests/bug_72740.phpt
+++ b/tests/bug_72740.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Solr Bug #72740 - addQueryField return wrong query
+Solr Bug #72740 - addPhraseField return wrong query
 --SKIPIF--
 <?php require_once 'skip.if.server_not_configured.inc'; ?>
 --FILE--
@@ -23,11 +23,36 @@ $dismaxQuery->addPhraseField( "phraseField2", 5, 1 );
 $dismaxQuery->addSortField('score', SolrQuery::ORDER_DESC);
 $dismaxQuery->addSortField('manufacturedate_dt', SolrQuery::ORDER_DESC);
 
+// Scenario 1: DisMax Query Parser - Adds Phrase Fields with both boost and slop.
+// Expect:
+// - pf parameter should list each phrase field with ~ and ^ prefix for slop and boost value respectively.
+$queryResponse = $client->query( $dismaxQuery );
+
+print_r($queryResponse->getResponse()->responseHeader->params);
+
+// Scenario 2: Same as Scenario 1, now including explicit query fields too.
+// Expect:
+// - pf parameter should list each phrase field with ~ and ^ prefix for slop and boost value respectively.
+// - qf parameter should list each query field with a trailing ^ (no boost here).
+$dismaxQuery->addQueryField('score');
+$dismaxQuery->addQueryField('manufacturedate_dt');
 
 $queryResponse = $client->query( $dismaxQuery );
 
 print_r($queryResponse->getResponse()->responseHeader->params);
 
+// Scenario 3: Same as Scenario 2, now including explicit boost value for the query fields.
+// Expect:
+// - pf parameter should list each phrase field with ~ and ^ prefix for slop and boost value respectively.
+// - qf parameter should list each query field with a ^ prefix for boost value.
+$dismaxQuery->removeQueryField('score');
+$dismaxQuery->removeQueryField('manufacturedate_dt');
+$dismaxQuery->addQueryField('score', 3);
+$dismaxQuery->addQueryField('manufacturedate_dt', 7);
+
+$queryResponse = $client->query( $dismaxQuery );
+
+print_r($queryResponse->getResponse()->responseHeader->params);
 ?>
 --EXPECTF--
 SolrObject Object
@@ -35,6 +60,28 @@ SolrObject Object
     [q] => *:*
     [defType] => edismax
     [indent] => on
+    [pf] => phraseField1~5^10 phraseField2~1^5
+    [sort] => score desc,manufacturedate_dt desc
+    [version] => 2.2
+    [wt] => xml
+)
+SolrObject Object
+(
+    [q] => *:*
+    [defType] => edismax
+    [indent] => on
+    [qf] => score^ manufacturedate_dt^
+    [pf] => phraseField1~5^10 phraseField2~1^5
+    [sort] => score desc,manufacturedate_dt desc
+    [version] => 2.2
+    [wt] => xml
+)
+SolrObject Object
+(
+    [q] => *:*
+    [defType] => edismax
+    [indent] => on
+    [qf] => score^3 manufacturedate_dt^7
     [pf] => phraseField1~5^10 phraseField2~1^5
     [sort] => score desc,manufacturedate_dt desc
     [version] => 2.2


### PR DESCRIPTION
HI @0mars,
https://github.com/php/pecl-search_engine-solr/commit/b1b44e0a22bcce8f625707248d0b4d3630935359#diff-ab0834017b5c60ae382501bce9a32bbc added a breaking regression when using Query Fields qith no boost value due to a "NUL byte issue".
It has been there since 2.5 years ago: most of - i.e. not all - the package maintainers in several distro were still using 2.4.0 with just few patches for 7.2 compat.
Test coverage was unfortunately incomplete to highlight the `#0;` issue in the `qf` parameter.

_2.5.0_ is finally out and using it under the condition above breaks any expected response; the improved test now shows the issue:
```diff
# make test TESTS="--show-all tests/bug_72740.phpt"
[cut]
========DIFF========
016+     [qf] => score#0; manufacturedate_dt#0;
016-     [qf] => score^ manufacturedate_dt^
========DONE========
```

Long story short, I discovered this issue since months in a project called Moodle within the context of its CI Docker Toolbox: you can read more in https://github.com/moodlehq/moodle-php-apache/issues/16 and https://github.com/moodlehq/moodle-php-apache/issues/19 but limited spare time and the availability of workarounds kept me far from proposing kind of fix, waiting for the release of 2.5.0.

On 7/7 I found some spare time to explore the code and to propose a quick fix to highlight where the problem was (https://github.com/scara/pecl-search_engine-solr/commit/c2c94b459ceab41df93cfa8a635f0578aef73a83) and posted it into https://bugs.php.net/bug.php?id=75631: @glensc was kind enough to do a quick peer review (really appreciated!).
I've decided to keep the initial quick fix in this PR since it looks like the way the code is actually managing the _NULL byte check_, **even** if @glensc is **super right** in suggesting a better refactoring which IMHO should be done at any level in the code to remove the pattern of checking for the value to be `NULL` and then via `strlen() > 0` since it has been initialized with an empty string i.e. `\0`.

For the record, https://bugs.php.net/bug.php?id=72740 is still open even if it has been already "addressed".

HTH,
Matteo