### PR TITLE
Tests - Ignore curl lib debug message

### DIFF
--- a/tests/019.solrclient_getdebug.phpt
+++ b/tests/019.solrclient_getdebug.phpt
@@ -31,7 +31,8 @@ foreach ( $lines as $line) {
 		0 === strpos($line, 'Server') ||
 		0 === strpos($line, 'Hostname') ||
 		0 === strpos($line, 'TCP_NODELAY') || 
-	    0 === strpos($line, 'Accept-Encoding')
+		0 === strpos($line, 'Accept-Encoding') ||
+		0 === strpos($line, 'Curl_http_done')
 		) {
 		$print = false;
 	} else {


### PR DESCRIPTION
Annoying debug message, it rises a failure in `tests/019.solrclient_getdebug.phpt`.
The curl debug message was removed in curl 7.53.0, https://curl.haxx.se/changes.html#7_53_0:
```
...
- http: remove "Curl_http_done: called premature" message
...
```
Test result w/o this PR:
```bash
# docker run --rm -it -v /path/to/php/pecl-search_engine-solr:/tmp/pecl-search_engine-solr php:7.2.20-apache bash
root@821f89163776:/var/www/html# php -v && php --ri curl | grep -E "(cURL|Version)"
PHP 7.2.20 (cli) (built: Jul 10 2019 00:53:14) ( NTS )
Copyright (c) 1997-2018 The PHP Group
Zend Engine v3.2.0, Copyright (c) 1998-2018 Zend Technologies
cURL support => enabled
cURL Information => 7.52.1
SSL Version => OpenSSL/1.0.2r
ZLib Version => 1.2.8
libSSH Version => libssh2/1.7.0
root@821f89163776:/var/www/html# apt-get update
root@821f89163776:/var/www/html# apt-get install -y --no-install-recommends libcurl4-openssl-dev libxml2-dev
root@821f89163776:/var/www/html# cd /tmp/pecl-search_engine-solr/
root@821f89163776:/tmp/pecl-search_engine-solr# phpize
root@821f89163776:/tmp/pecl-search_engine-solr# make clean
root@821f89163776:/tmp/pecl-search_engine-solr# ./configure
root@821f89163776:/tmp/pecl-search_engine-solr# make
root@821f89163776:/tmp/pecl-search_engine-solr# make install
root@821f89163776:/tmp/pecl-search_engine-solr# make test TESTS="--show-all tests/019.solrclient_getdebug.phpt"
[cut]
========DIFF========
009+ Curl_http_done: called premature == 0
========DONE========
[cut]
```
HTH,
Matteo