### PR TITLE
Fix uint ulong, add missing libs for curl, fix Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install:
 addons:
   apt:
     packages:
-      - php5-cli
+      - php7.0-cli
       - php-pear
       - libxml2-dev
       - libcurl4-gnutls-dev

--- a/config.w32
+++ b/config.w32
@@ -3,13 +3,29 @@
 // config.w32 for solr extension
 
 ARG_ENABLE('solr', 'Whether to enable Apache Solr support', 'no');
-ARG_ENABLE('solr-debug', 'Whether to enable Solr debugging support', 'no');
+if (typeof PHP_SOLR_DEBUG == 'undefined') PHP_SOLR_DEBUG = 'no';
 
 if(PHP_SOLR != 'no')
 {
 	if(!CHECK_LIB('libcurl_a.lib;libcurl.lib', 'solr', PHP_SOLR) ||
 		!CHECK_HEADER_ADD_INCLUDE('curl/easy.h', 'CFLAGS_SOLR')) {
 		WARNING('solr was not enabled; curl libraries and/or headers not found');
+		PHP_SOLR = "no";
+	}
+	if(!CHECK_LIB('libssh2_a.lib;libssh2.lib', 'solr', PHP_SOLR)) {
+		WARNING('solr was not enabled; libssh2 library not found');
+		PHP_SOLR = "no";
+	}
+	if(!CHECK_LIB('nghttp2_a.lib;nghttp2.lib', 'solr', PHP_SOLR)) {
+		WARNING('solr was not enabled; nghttp2 library not found');
+		PHP_SOLR = "no";
+	}
+	if(!CHECK_LIB('crypt32.lib', 'solr', PHP_SOLR)) {
+		WARNING('solr was not enabled; crypt32 library not found');
+		PHP_SOLR = "no";
+	}
+	if(!CHECK_LIB('normaliz.lib', 'solr', PHP_SOLR)) {
+		WARNING('solr was not enabled; IDN libraries (normaliz.lib) not found');
 		PHP_SOLR = "no";
 	}
 	if(!((CHECK_LIB('libssl.lib', 'solr', PHP_SOLR)
@@ -48,10 +64,10 @@ if(PHP_SOLR != 'no')
 		PHP_SOLR = "no";
 	}
 	if(PHP_SOLR != 'no') {
-		if(PHP_SOLR_DEBUG == 'no') {
-			AC_DEFINE('SOLR_DEBUG_OFF', 1, 'Solr debugging set to off');
-		} else {
+		if(PHP_SOLR_DEBUG == 'yes') {
 			AC_DEFINE('SOLR_DEBUG', 1, 'Solr debugging set to on');
+		} else {
+			AC_DEFINE('SOLR_DEBUG_OFF', 1, 'Solr debugging set to off');
 		}
 
 		var dll = get_define('PHPDLL');

--- a/pecl-compat/src/zend_hash.h
+++ b/pecl-compat/src/zend_hash.h
@@ -289,8 +289,8 @@ static zend_always_inline int compat_zend_hash_get_current_key_ex(const HashTabl
 {
 	int status;
 	char *str;
-	uint str_length;
-	ulong num;
+	uint32_t str_length;
+	zend_ulong num;
 
 	status = zend_hash_get_current_key_ex(ht, &str, &str_length, &num, 0, pos);
 	if (status == HASH_KEY_IS_STRING) {
@@ -311,8 +311,8 @@ static zend_always_inline int compat_zend_hash_str_get_current_key_ex(const Hash
 	, zend_bool duplicate, HashPosition *pos)
 {
 	int status;
-	uint length;
-	ulong num;
+	uint32_t length;
+	zend_ulong num;
 
 	status = zend_hash_get_current_key_ex(ht, str_index, &length, &num, duplicate, pos);
 	if (status == HASH_KEY_IS_STRING) {

--- a/src/php7/php_solr.c
+++ b/src/php7/php_solr.c
@@ -1296,7 +1296,7 @@ PHP_RINIT_FUNCTION(solr)
 	zend_bool persistent   = SOLR_HASHTABLE_PERSISTENT;
 
 	/* Initial size of the HashTable */
-	uint nSize             = SOLR_INITIAL_HASH_TABLE_SIZE;
+	uint32_t nSize             = SOLR_INITIAL_HASH_TABLE_SIZE;
 
 	ALLOC_HASHTABLE(SOLR_GLOBAL(documents));
 	ALLOC_HASHTABLE(SOLR_GLOBAL(clients));

--- a/src/php7/php_solr_collapse_function.c
+++ b/src/php7/php_solr_collapse_function.c
@@ -24,7 +24,7 @@
 PHP_METHOD(SolrCollapseFunction, __construct)
 {
     long int index = SOLR_UNIQUE_FUNCTION_INDEX();
-    uint nSize = SOLR_INITIAL_HASH_TABLE_SIZE;
+    uint32_t nSize = SOLR_INITIAL_HASH_TABLE_SIZE;
     solr_function_t *solr_function_dest = NULL;
     zval *objptr = getThis();
 #ifdef PHP_7

--- a/src/php7/php_solr_document.c
+++ b/src/php7/php_solr_document.c
@@ -475,7 +475,7 @@ static int solr_unserialize_document_object(solr_document_t *doc_entry, char *se
 PHP_METHOD(SolrDocument, __construct)
 {
 	zval *objptr = getThis();
-	ulong document_index = SOLR_UNIQUE_DOCUMENT_INDEX();
+	zend_ulong document_index = SOLR_UNIQUE_DOCUMENT_INDEX();
 
 	if (solr_init_document(document_index) == NULL)
 	{
@@ -742,7 +742,7 @@ PHP_METHOD(SolrDocument, current)
 PHP_METHOD(SolrDocument, key)
 {
 	solr_document_t *doc_entry = NULL;
-	ulong num_index = 0L;
+	zend_ulong num_index = 0L;
 	HashTable *doc_fields = NULL;
 	zend_string *field_name_str;
 
@@ -838,7 +838,7 @@ PHP_METHOD(SolrDocument, unserialize)
 	solr_char_t *serialized = NULL;
 	COMPAT_ARG_SIZE_T serialized_length  = 0;
 	zval *objptr = getThis();
-	ulong document_index = SOLR_UNIQUE_DOCUMENT_INDEX();
+	zend_ulong document_index = SOLR_UNIQUE_DOCUMENT_INDEX();
 	solr_document_t *doc_entry = NULL;
 
 	/* Process the parameters passed to the default constructor */
@@ -1184,7 +1184,7 @@ PHP_METHOD(SolrDocument, merge)
 	zend_hash_merge(destination_document->fields, source_document->fields, p_copy_ctor, (int) overwrite);
 
 	/* Update the field count */
-	destination_document->field_count = (uint) zend_hash_num_elements(destination_document->fields);
+	destination_document->field_count = (uint32_t) zend_hash_num_elements(destination_document->fields);
 
 	RETURN_TRUE;
 }

--- a/src/php7/php_solr_extract.c
+++ b/src/php7/php_solr_extract.c
@@ -35,7 +35,7 @@ extern HashTable *ustreams;
 
 PHP_SOLR_API int solr_init_ustream(zval *obj)
 {
-    ulong index = SOLR_UNIQUE_USTREAM_INDEX();
+    zend_ulong index = SOLR_UNIQUE_USTREAM_INDEX();
     solr_ustream_t *ustream_entry = NULL;
 
     ustream_entry = pemalloc(sizeof(solr_ustream_t), 0);

--- a/src/php7/php_solr_input_document.c
+++ b/src/php7/php_solr_input_document.c
@@ -708,7 +708,7 @@ PHP_METHOD(SolrInputDocument, merge)
 	zend_hash_merge(destination_document->fields, source_document->fields, p_copy_ctor, overwrite);
 
 	/* Update the field count */
-	destination_document->field_count = (uint) zend_hash_num_elements(destination_document->fields);
+	destination_document->field_count = (uint32_t) zend_hash_num_elements(destination_document->fields);
 
 	RETURN_TRUE;
 }

--- a/src/php7/php_solr_params.c
+++ b/src/php7/php_solr_params.c
@@ -424,7 +424,7 @@ static int solr_unserialize_solr_params_object(const char *serialized, int size,
 	solr_params_t *solr_params = NULL;
 	long int params_index = SOLR_UNIQUE_PARAMS_INDEX();
 	solr_params_t tmp_solr_params;
-	uint nSize = SOLR_INITIAL_HASH_TABLE_SIZE;
+	uint32_t nSize = SOLR_INITIAL_HASH_TABLE_SIZE;
 	HashTable *params_ht = NULL;
 	xmlDoc *doc = NULL;
 	xmlXPathContext *xpathctxt;

--- a/src/php7/solr_functions_document.c
+++ b/src/php7/solr_functions_document.c
@@ -150,7 +150,7 @@ PHP_SOLR_API int solr_document_insert_field_value_ex(solr_field_list_t *queue, c
  */
 PHP_SOLR_API solr_document_t *solr_init_document(long int document_index)
 {
-    uint nSize = SOLR_INITIAL_HASH_TABLE_SIZE;
+    uint32_t nSize = SOLR_INITIAL_HASH_TABLE_SIZE;
     solr_document_t *doc_ptr = NULL;
     solr_document_t *doc_entry;
 
@@ -194,7 +194,7 @@ PHP_SOLR_API solr_document_t *solr_init_document(long int document_index)
  */
 PHP_SOLR_API solr_document_t *solr_input_doc_ctor(zval *objptr)
 {
-    ulong document_index = SOLR_UNIQUE_DOCUMENT_INDEX();
+    zend_ulong document_index = SOLR_UNIQUE_DOCUMENT_INDEX();
     solr_document_t *solr_doc = NULL;
 
     if ((solr_doc = solr_init_document(document_index)) == NULL)

--- a/src/php7/solr_functions_helpers.c
+++ b/src/php7/solr_functions_helpers.c
@@ -1547,7 +1547,7 @@ PHP_SOLR_API void solr_solrfunc_to_string(solr_function_t *function, solr_string
 
     solr_string_t *value;
     zend_string *key;
-    ulong num_idx;
+    zend_ulong num_idx;
     ZEND_HASH_FOREACH_KEY_PTR(function->params, num_idx, key, value)
     {
         (void)num_idx; /* silent -Wunused-but-set-variable */
@@ -1590,7 +1590,7 @@ PHP_SOLR_API void solr_destroy_ustream_zv(zval *obj)
 PHP_SOLR_API int solr_fetch_ustream_entry(zval *objptr, solr_ustream_t **stream_entry TSRMLS_DC)
 {
     zval rv, *index_zv;
-    ulong index = 0;
+    zend_ulong index = 0;
     index_zv = zend_read_property(Z_OBJCE_P(objptr), objptr, SOLR_INDEX_PROPERTY_NAME, sizeof(SOLR_INDEX_PROPERTY_NAME)-1, 1, &rv);
 
     index = Z_LVAL_P(index_zv);

--- a/src/php7/solr_functions_params.c
+++ b/src/php7/solr_functions_params.c
@@ -22,7 +22,7 @@
 
 PHP_SOLR_API int solr_init_params(solr_params_t *solr_params, long int index)
 {
-    uint nSize = SOLR_INITIAL_HASH_TABLE_SIZE;
+    uint32_t nSize = SOLR_INITIAL_HASH_TABLE_SIZE;
     solr_params = (solr_params_t *)pemalloc( sizeof(solr_params_t), SOLR_PARAMS_PERSISTENT);
 
     memset(solr_params, 0, sizeof(solr_params_t));
@@ -605,7 +605,7 @@ PHP_SOLR_API void solr_normal_param_value_fetch(solr_param_t *solr_param, solr_s
 
 	} else {
 
-		ulong n_loops = solr_param->count - 1;
+		zend_ulong n_loops = solr_param->count - 1;
 
 		while(n_loops)
 		{
@@ -646,7 +646,7 @@ PHP_SOLR_API void solr_simple_list_param_value_fetch(solr_param_t *solr_param, s
 {
 	solr_param_value_t *current_ptr = solr_param->head;
 	solr_char_t list_delimiter = ','; /* Comma 0x2C */
-	ulong n_loops = solr_param->count - 1;
+	zend_ulong n_loops = solr_param->count - 1;
 	auto solr_string_t tmp_buffer;
 	zend_string *url_encoded_list = NULL;
 
@@ -686,7 +686,7 @@ PHP_SOLR_API void solr_arg_list_param_value_fetch(solr_param_t *solr_param, solr
 	solr_param_value_t *current_ptr = solr_param->head;
 	solr_char_t list_delimiter = solr_param->delimiter;
 	solr_char_t separator = solr_param->arg_separator;
-	ulong n_loops = solr_param->count - 1;
+	zend_ulong n_loops = solr_param->count - 1;
 	solr_string_t tmp_buffer;
 	zend_string *url_encoded_list = NULL;
 
@@ -883,7 +883,7 @@ PHP_SOLR_API void solr_normal_param_value_tostring(solr_param_t *solr_param, sol
 
 	} else {
 
-		ulong n_loops = solr_param->count - 1;
+		zend_ulong n_loops = solr_param->count - 1;
 		zend_string *url_encoded_param_value = NULL;
 
 		while(n_loops)
@@ -936,7 +936,7 @@ PHP_SOLR_API void solr_simple_list_param_value_tostring(solr_param_t *solr_param
 {
 	solr_param_value_t *current_ptr = solr_param->head;
 	solr_char_t list_delimiter = solr_param->delimiter; /* Comma 0x2C */
-	ulong n_loops = solr_param->count - 1;
+	zend_ulong n_loops = solr_param->count - 1;
 	auto solr_string_t tmp_buffer;
 	zend_string *url_encoded_list = NULL;
 
@@ -981,7 +981,7 @@ PHP_SOLR_API void solr_arg_list_param_value_tostring(solr_param_t *solr_param, s
 	solr_param_value_t *current_ptr = solr_param->head;
 	solr_char_t list_delimiter = solr_param->delimiter;
 	solr_char_t separator = solr_param->arg_separator;
-	ulong n_loops = solr_param->count - 1;
+	zend_ulong n_loops = solr_param->count - 1;
 	solr_string_t tmp_buffer;
 	zend_string *url_encoded_list = NULL;
 

--- a/src/php7/solr_types.h
+++ b/src/php7/solr_types.h
@@ -163,7 +163,7 @@ typedef struct {
 
 	char str[CURL_ERROR_SIZE + 1]; /* Stores the error message */
 
-	uint  number;	/* Stores the error number */
+	uint32_t  number;	/* Stores the error number */
 
 } solr_curl_error_t;
 
@@ -265,9 +265,9 @@ typedef struct {
 
 typedef struct {
 
-	ulong client_index;     	   	/* Unique for the SolrClient instance. Used as index in HashTables */
+	zend_ulong client_index;     	   	/* Unique for the SolrClient instance. Used as index in HashTables */
 
-	uint request_count; 			/* The number of requests made from this client */
+	uint32_t request_count; 			/* The number of requests made from this client */
 
 	solr_client_options_t options;	/* The connection options for this client */
 
@@ -305,9 +305,9 @@ typedef struct {
 
 	double field_boost;         /* The boost value for this field */
 
-	uint count;                 /* The number of values in this field */
+	uint32_t count;                 /* The number of values in this field */
 
-	uint modified;              /* marks field as getting modified */
+	uint32_t modified;              /* marks field as getting modified */
 
 	solr_char_t *field_name;   	/* The name of the field */
 
@@ -321,9 +321,9 @@ typedef struct {
 /* {{{ Types for Documents and Document Collections */
 typedef struct {
 
-	ulong document_index;   /* Unique for the SolrInputDocument instance. Used as index in HashTables */
+	zend_ulong document_index;   /* Unique for the SolrInputDocument instance. Used as index in HashTables */
 
-	uint field_count;  		/* Number of fields in this document */
+	uint32_t field_count;  		/* Number of fields in this document */
 
 	double document_boost;	/* The boost value for this document */
 
@@ -382,7 +382,7 @@ typedef struct {
 
 	solr_param_type_t type;							/* What type of query parameter this is */
 
-	uint count;               		 				/* The number of values for this parameter */
+	uint32_t count;               		 				/* The number of values for this parameter */
 
 	solr_char_t *param_name;    					/* The name of the parameter */
 
@@ -415,9 +415,9 @@ typedef void (*solr_param_tostring_func_t)(solr_param_t *solr_param, solr_string
 
 typedef struct {
 
-	ulong params_index;	/* The index for this object in the HashTable */
+	zend_ulong params_index;	/* The index for this object in the HashTable */
 
-	uint  params_count;	/* The number of parameters for the query object */
+	uint32_t  params_count;	/* The number of parameters for the query object */
 
 	HashTable *params;	/* The HashTable for storing query parameters */
 
@@ -428,7 +428,7 @@ typedef struct {
 /* {{{ solr function/localparams type */
 typedef struct {
 
-    ulong function_index; /* The index for this object in the HashTable */
+    zend_ulong function_index; /* The index for this object in the HashTable */
 
     solr_char_t *name;
     size_t name_length;
@@ -469,13 +469,13 @@ typedef struct {
 /* {{{ Extension Global : This should be the last data type declared. More members may be added later. */
 ZEND_BEGIN_MODULE_GLOBALS(solr)
 
-	uint request_count;      /* The number of times PHP_RINIT has been called */
+	uint32_t request_count;      /* The number of times PHP_RINIT has been called */
 
-	uint document_count;     /* The number of active SolrDocuments in this request */
+	uint32_t document_count;     /* The number of active SolrDocuments in this request */
 
-	uint client_count;	     /* The number of active SolrClients in this request */
+	uint32_t client_count;	     /* The number of active SolrClients in this request */
 
-	uint functions_count;    /* The number of active Functions in this request */
+	uint32_t functions_count;    /* The number of active Functions in this request */
 
 	HashTable *documents;	 /* HashTable for storing solr_document_t documents */
 


### PR DESCRIPTION
This PR fixes:
1. The removal of the Windows typedefs uint and ulong:
https://github.com/php/php-src/blob/PHP-7.4/UPGRADING.INTERNALS#L216
2. The missing libs, due to recent changes to default libcurl build
php/php-src@a1ba300#diff-4e6782d127d4f20ec4acfb42474941e5
3. It fixes the Travis checks, that were failing because of a missing php5-cli

After this PR config.w32 will work for the Windows building of PHP 7.0 up until PHP 7.4