### PR TITLE
Fix float parsing on musl

### DIFF
--- a/src/php7/solr_functions_params.c
+++ b/src/php7/solr_functions_params.c
@@ -766,7 +766,7 @@ PHP_SOLR_API void solr_normal_param_value_display_double(solr_param_t *solr_para
 {
 	solr_param_value_t *current_ptr = solr_param->head;
 
-	double return_value = atof(current_ptr->contents.normal.str);
+	double return_value = zend_strtod(current_ptr->contents.normal.str, (const char **) NULL);
 
 	ZVAL_DOUBLE(param_value, return_value);
 }


### PR DESCRIPTION
Using the zend strtod implementation fixes this.

Faced with it packaging for Alpinelinux (x86-64, x86, s390x)

```
testing/php7-pecl-solr/src/solr-2.5.0/tests$ cat 063.solrquery_HighlightingParameters.diff 
030+ float(0.0025000000000004)
030- float(0.0025)
```