### PR TITLE
PHP8/8.1 windows fixes

### DIFF
--- a/config.w32
+++ b/config.w32
@@ -28,10 +28,8 @@ if(PHP_SOLR != 'no')
 		WARNING('solr was not enabled; IDN libraries (normaliz.lib) not found');
 		PHP_SOLR = "no";
 	}
-	if(!((CHECK_LIB('libssl.lib', 'solr', PHP_SOLR)
-		&& CHECK_LIB('libcrypto.lib', 'solr', PHP_SOLR)) ||
-		(CHECK_LIB('ssleay32.lib', 'solr', PHP_SOLR)
-		&& CHECK_LIB('libeay32.lib', 'solr', PHP_SOLR)))) {
+	if(!(CHECK_LIB('libssl.lib;ssleay32.lib', 'solr', PHP_SOLR)
+		&& CHECK_LIB('libcrypto.lib;libeay32.lib', 'solr', PHP_SOLR))) {
 		WARNING('solr was not enabled; openssl libraries not found');
 		PHP_SOLR = "no";
 	}

--- a/config.w32
+++ b/config.w32
@@ -64,18 +64,11 @@ if(PHP_SOLR != 'no')
 			AC_DEFINE('SOLR_DEBUG_OFF', 1, 'Solr debugging set to off');
 		}
 
-		var dll = get_define('PHPDLL');
         var old_conf_dir = configure_module_dirname;
 
         /* XXX tricky job here, override configure_module_dirname, define the basic extension,
             then set it back*/
-        if (null != dll.match(/^php5/)) {
-            configure_module_dirname = configure_module_dirname + "\\src\\php5";
-        } else if (null != dll.match(/^php7/)) {
-            configure_module_dirname = configure_module_dirname + "\\src\\php7";
-        } else {
-            ERROR("Cannot match any known PHP version with '" + dll + "'");
-        }
+        configure_module_dirname = configure_module_dirname + "\\src\\php7";
 
 		EXTENSION('solr',
 					'php_solr.c php_solr_client.c php_solr_document.c php_solr_exception.c ' +

--- a/config.w32
+++ b/config.w32
@@ -59,10 +59,6 @@ if(PHP_SOLR != 'no')
 			PHP_SOLR = "no";
 		}
 	}
-	if(PHP_JSON == 'no' || !ADD_EXTENSION_DEP('solr', 'json')) {
-		WARNING('solr was not enabled; json is not enabled');
-		PHP_SOLR = "no";
-	}
 	if(PHP_SOLR != 'no') {
 		if(PHP_SOLR_DEBUG == 'yes') {
 			AC_DEFINE('SOLR_DEBUG', 1, 'Solr debugging set to on');

--- a/pecl-compat/compat.h
+++ b/pecl-compat/compat.h
@@ -77,9 +77,13 @@
 #endif
 
 #ifdef PHP_WIN32
-#include <win32/php_stdint.h>
+#	if PHP_MAJOR_VERSION < 8
+#		include <win32/php_stdint.h>
+#	else
+#		include <inttypes.h>
+#	endif
 #else
-#include <inttypes.h>
+#	include <inttypes.h>
 #endif
 
 #if ZEND_EXTENSION_API_NO >= PHP_5_6_X_API_NO

--- a/src/php7/php_solr.h
+++ b/src/php7/php_solr.h
@@ -882,6 +882,15 @@ PHP_SOLR_API void solr_document_field_unset_property(zend_object *object, zend_s
 
 int add_phrase_field(zval *obj, solr_char_t *pname, zval *boost, zval *slop, solr_char_t *field_name, COMPAT_ARG_SIZE_T field_name_len);
 
+/* Per https://wiki.php.net/rfc/internal_method_return_types, "Non-final
+ * internal method return types - when possible - are declared tentatively in
+ * PHP 8.1, and they will become enforced in PHP 9.0." This can be revisited
+ * when more general typing improvements are made in PHPC-1709. */
+#ifndef ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX
+#define ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(name, return_reference, required_num_args, type, allow_null) \
+	ZEND_BEGIN_ARG_INFO_EX(name, 0, return_reference, required_num_args)
+#endif
+
 #include "solr_macros.h"
 #include "php_solr_dismax_query.h"
 

--- a/src/php7/solr_functions_helpers.c
+++ b/src/php7/solr_functions_helpers.c
@@ -18,7 +18,9 @@
 
 #include "php_solr.h"
 
+#ifndef PHP_WIN32
 ZEND_EXTERN_MODULE_GLOBALS(json)
+#endif
 
 /** ************************************************************************ **/
 /** FUNCTIONS FOR DECLARING CONSTANTS                                        **/


### PR DESCRIPTION
@0mars @alexgit2k @cmb69 
All fixes to make the extension compile on Windows for PHP 8.0 and PHP 8.1 in one PR

The fatal errors that I reported at https://github.com/remicollet/pecl-search_engine-solr/pull/1#issuecomment-1068493840 were caused by a missing definition of `ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX()` in PHP 8.0

Please review and merge.