### PR TITLE
Fix curl check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,6 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y libcurl4-openssl-dev
-          cd /usr/include && sudo ln -s x86_64-linux-gnu/curl
       - name: Install PHP ${{ matrix.php }}
         uses: shivammathur/setup-php@v2
         with:

--- a/config.m4
+++ b/config.m4
@@ -4,46 +4,7 @@ dnl Configuring the CURL external library
 dnl This folder is the grand-parent folder of easy.h
 PHP_ARG_WITH(curl, for cURL support, [  --with-curl[=DIR]		SOLR : libcurl install prefix])
 
-if test -r $PHP_CURL/include/curl/easy.h; then
-	CURL_DIR=$PHP_CURL
-	AC_MSG_RESULT(curl headers found in $PHP_CURL)
-else
-	AC_MSG_CHECKING(for cURL in default path)
-	for i in /usr/local /usr; do
-	  	if test -r $i/include/curl/easy.h; then
-			CURL_DIR=$i
-			AC_MSG_RESULT(found in $i)
-			break
-	  	fi
-	done
-fi
-
-if test -z "$CURL_DIR"; then
-	AC_MSG_RESULT(not found)
-	AC_MSG_ERROR([Please reinstall the libcurl distribution -
-	easy.h should be in <curl-dir>/include/curl/])
-fi
-
-CURL_CONFIG="curl-config"
-AC_MSG_CHECKING(for cURL 7.15.0 or greater)
-
-if ${CURL_DIR}/bin/curl-config --libs > /dev/null 2>&1; then
-	CURL_CONFIG=${CURL_DIR}/bin/curl-config
-else
-	if ${CURL_DIR}/curl-config --libs > /dev/null 2>&1; then
-  		CURL_CONFIG=${CURL_DIR}/curl-config
-	fi
-fi
-
-curl_version_full=`$CURL_CONFIG --version`
-curl_version=`echo ${curl_version_full} | sed -e 's/libcurl //' | $AWK 'BEGIN { FS = "."; } { printf "%d", ($1 * 1000 + $2) * 1000 + $3;}'`
-
-if test "$curl_version" -ge 7015000; then
-	AC_MSG_RESULT($curl_version_full)
-	CURL_LIBS=`$CURL_CONFIG --libs`
-else
-	AC_MSG_ERROR([The Solr extension does not support libcurl libraries < 7.15.0. Please update your libraries])
-fi
+PKG_CHECK_MODULES([CURL], [libcurl >= 7.15.0])
 
 PHP_ARG_ENABLE(solr, whether to enable the Solr extension,
 [  --enable-solr         Enable solr support])


### PR DESCRIPTION
Using newer methods to check for libcurl.

This solves issues with multiarch on debian where easy.h is not found in /usr/include.
Then the file is instead in /usr/include/x86_64-linux-gnu/curl/.