### PR TITLE
Add GitHub CI pipeline for tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Run tests
         run: make test
         env:
-          TEST_PHP_ARGS: --define extension=json.so -q
+          TEST_PHP_ARGS: '--define extension=json.so -q'
     services:
       solr:
         image: ingimarsson/pecl-solr

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
           make
       - name: Run tests
         run: make test
+        env:
+          TEST_PHP_ARGS: --define extension=json.so -q
     services:
       solr:
         image: ingimarsson/pecl-solr

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,15 +21,16 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           extensions: curl, json
+      - name: Set TEST_PHP_ARGS
+        if: ${{ startsWith(matrix.php, '7.') }}
+        run: echo "TEST_PHP_ARGS='-d extension=$(php -i | grep extension_dir  | cut -d " " -f 5 | head -n 1)/json.so -q'" >> $GITHUB_ENV
       - name: Build PHP extension
         run: |
           phpize
           ./configure
           make
       - name: Run tests
-        run: make test
-        env:
-          TEST_PHP_ARGS: '-d extension=json.so -q'
+        run: TEST_PHP_ARGS="$TEST_PHP_ARGS -q" make test
     services:
       solr:
         image: ingimarsson/pecl-solr

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
         run: |
           sudo apt update
           sudo apt-get install libcurl4-openssl-dev libxml2 libxml2-dev
+          cd /usr/include && sudo ln -s x86_64-linux-gnu/curl
       - name: Install PHP ${{ matrix.php }}
         uses: shivammathur/setup-php@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       # For PHP 7.x we need to specify a full path to json.so, for PHP 8.x the JSON module is compiled into the core binary
       - name: Set TEST_PHP_ARGS
         if: ${{ startsWith(matrix.php, '7.') }}
-        run: echo "TEST_PHP_ARGS='-d extension=$(php -i | grep extension_dir  | cut -d " " -f 5 | head -n 1)/json.so -q'" >> $GITHUB_ENV
+        run: echo "TEST_PHP_ARGS='-d extension=$(php -i | grep extension_dir | cut -d " " -f 5 | head -n 1)/json.so -q'" >> $GITHUB_ENV
       - name: Build PHP extension
         run: |
           phpize
@@ -35,6 +35,6 @@ jobs:
         run: TEST_PHP_ARGS="$TEST_PHP_ARGS -q" make test
     services:
       solr:
-        image: ingimarsson/pecl-solr
+        image: stefna/pecl-solr
         ports:
           - 8983:8983

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           extensions: curl, json
+      # For PHP 7.x we need to specify a full path to json.so, for PHP 8.x the JSON module is compiled into the core binary
       - name: Set TEST_PHP_ARGS
         if: ${{ startsWith(matrix.php, '7.') }}
         run: echo "TEST_PHP_ARGS='-d extension=$(php -i | grep extension_dir  | cut -d " " -f 5 | head -n 1)/json.so -q'" >> $GITHUB_ENV
@@ -29,6 +30,7 @@ jobs:
           phpize
           ./configure
           make
+      # Run tests (we add the -q flag to skip the "send report?" question at the end)
       - name: Run tests
         run: TEST_PHP_ARGS="$TEST_PHP_ARGS -q" make test
     services:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    continue-on-error: false
+    strategy:
+      matrix:
+        php: ['8.2']
+        #php: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          sudo apt-get install libcurl4-openssl-dev libxml2 libxml2-dev
+      - name: Install PHP ${{ matrix.php }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: curl
+      - name: Build PHP extension
+        run: |
+          phpize
+          ./configure
+          make
+      - name: Run tests
+        run: make test
+    services:
+      solr:
+        image: ingimarsson/pecl-solr
+        ports:
+          - 8983:8983

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Run tests
         run: make test
         env:
-          TEST_PHP_ARGS: '--define extension=json.so -q'
+          TEST_PHP_ARGS: '-d extension=json.so -q'
     services:
       solr:
         image: ingimarsson/pecl-solr

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,7 @@ jobs:
     continue-on-error: false
     strategy:
       matrix:
-        php: ['8.2']
-        #php: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
+        php: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       # For PHP 7.x we need to specify a full path to json.so, for PHP 8.x the JSON module is compiled into the core binary
       - name: Set TEST_PHP_ARGS
         if: ${{ startsWith(matrix.php, '7.') }}
-        run: echo "TEST_PHP_ARGS='-d extension=$(php -i | grep extension_dir | cut -d " " -f 5 | head -n 1)/json.so -q'" >> $GITHUB_ENV
+        run: echo "TEST_PHP_ARGS=-d extension=$(php -i | grep extension_dir | cut -d " " -f 5 | head -n 1)/json.so" >> $GITHUB_ENV
       - name: Build PHP extension
         run: |
           phpize

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,8 @@ jobs:
         uses: actions/checkout@v3
       - name: Install dependencies
         run: |
-          sudo apt update
-          sudo apt-get install libcurl4-openssl-dev libxml2 libxml2-dev
+          sudo apt-get update
+          sudo apt-get install -y libcurl4-openssl-dev
           cd /usr/include && sudo ln -s x86_64-linux-gnu/curl
       - name: Install PHP ${{ matrix.php }}
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: curl
+          extensions: curl, json
       - name: Build PHP extension
         run: |
           phpize

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ It contains the fixture file definitions and other configurations for the Solr S
 
 To run the type 2 tests, you'll need docker to run the test server using the following command:
 
-```docker run -p 8983:8983 --name solr5 -t omars/solr53```
+```docker run -p 8983:8983 --name pecl-solr -t stefna/pecl-solr```
 
 PHPQA Guide: https://qa.php.net/write-test.php
 

--- a/tests/003.solrclient_options.phpt
+++ b/tests/003.solrclient_options.phpt
@@ -11,6 +11,7 @@ $options = array
 (
     'hostname' => SOLR_SERVER_HOSTNAME,
     'login'    => SOLR_SERVER_USERNAME,
+    'port'     => SOLR_SERVER_PORT,
     'password' => SOLR_SERVER_PASSWORD,
     'path'     => SOLR_SERVER_PATH,
 	'timeout'  => 400
@@ -37,6 +38,7 @@ print_r($pingResponse->getRawResponse());
 $options = array (
 		'hostname' => SOLR_SERVER_HOSTNAME,
 		'login' => SOLR_SERVER_USERNAME,
+		'port' => SOLR_SERVER_PORT,
 		'password' => SOLR_SERVER_PASSWORD,
 		'path' => SOLR_SERVER_PATH,
 		'proxy_host' => 'localhost',
@@ -56,6 +58,7 @@ try {
 $options = array (
 		'hostname' => SOLR_SERVER_HOSTNAME,
 		'login' => SOLR_SERVER_USERNAME,
+		'port' => SOLR_SERVER_PORT,
 		'password' => SOLR_SERVER_PASSWORD,
 		'path' => SOLR_SERVER_PATH,
 		'proxy_host' => 'localhost',
@@ -82,6 +85,7 @@ $options = array
 (
 		'hostname' => SOLR_SERVER_HOSTNAME,
 		'login'    => SOLR_SERVER_USERNAME,
+		'port'     => SOLR_SERVER_PORT,
 		'password' => SOLR_SERVER_PASSWORD,
 		'path'     => SOLR_SERVER_PATH,
 		'ssl_cert' => '/tmp/unavailable.crt',

--- a/tests/019.solrclient_getdebug.phpt
+++ b/tests/019.solrclient_getdebug.phpt
@@ -48,14 +48,14 @@ foreach ( $lines as $line) {
 --EXPECTF--
 Accept-Charset: utf-8
 Accept: */*
-Authorization: Basic YWRtaW46Y2hhbmdlaXQ=
-Connected to %s (%s) port 8983 (#0)
+Authorization: Basic %s
+Connected to %s (%s) port %s (#0)
 Connection #0 to host %s left intact
 Connection: keep-alive
 Content-Length: 0
 Content-Type: application/xml; charset=UTF-8
 HEAD /solr/collection1/admin/ping/?version=2.2&indent=on&wt=xml HTTP/1.1
 HTTP/1.1 200 OK
-Host: %s:8983
+Host: %s:%s
 Keep-Alive: 300
 User-Agent: %s

--- a/tests/107.solrresponse_getrawresponseheaders.phpt
+++ b/tests/107.solrresponse_getrawresponseheaders.phpt
@@ -36,7 +36,7 @@ $query_response = $client->query($query);
 $headers = $query_response->getRawResponseHeaders();
 print_r($headers);
 ?>
---EXPECT--
+--EXPECTF--
 HTTP/1.1 200 OK
 Content-Type: application/xml; charset=UTF-8
-Transfer-Encoding: chunked
+Content-Length: %s

--- a/tests/107.solrresponse_getrawresponseheaders.phpt
+++ b/tests/107.solrresponse_getrawresponseheaders.phpt
@@ -34,9 +34,20 @@ $query->addField('cat')->addField('features')->addField('id')->addField('timesta
 $query_response = $client->query($query);
 
 $headers = $query_response->getRawResponseHeaders();
-print_r($headers);
+
+$filteredHeaders = implode(
+	"\n",
+    array_filter(
+        explode("\r\n", $headers),
+        function($header) {
+            return strpos($header, 'HTTP') === 0 || strpos($header, 'Content-Type') === 0;
+        }
+    )
+);
+
+print_r($filteredHeaders);
+
 ?>
 --EXPECTF--
-HTTP/1.1 200 OK
-Content-Type: application/xml; charset=UTF-8
-Content-Length: %s
+HTTP/%s 200 OK
+Content-Type: %s

--- a/tests/109.solrresponse_getrequesturl.phpt
+++ b/tests/109.solrresponse_getrequesturl.phpt
@@ -36,4 +36,4 @@ $query_response = $client->query($query);
 echo $query_response->getRequestUrl();
 ?>
 --EXPECTF--
-http://%s:8983/solr/collection1/select/?version=2.2&indent=on&wt=xml
+http://%s:%s/solr/collection1/select/?version=2.2&indent=on&wt=xml

--- a/tests/160.solr_update_document_block.phpt
+++ b/tests/160.solr_update_document_block.phpt
@@ -2,7 +2,8 @@
 Solr - Fetch and Update nested documents
 --SKIPIF--
 <?php
-include 'skip.if.server_not_configured.inc';
+die("skip: does not work with Solr 6.3");
+//include 'skip.if.server_not_configured.inc';
 ?>
 --FILE--
 <?php

--- a/tests/160.solr_update_document_block.phpt
+++ b/tests/160.solr_update_document_block.phpt
@@ -2,8 +2,7 @@
 Solr - Fetch and Update nested documents
 --SKIPIF--
 <?php
-die("skip: does not work with Solr 6.3");
-//include 'skip.if.server_not_configured.inc';
+include 'skip.if.server_not_configured.inc';
 ?>
 --FILE--
 <?php

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -1,0 +1,11 @@
+FROM solr:6.3
+
+COPY collections collections
+
+RUN solr start &&\
+    solr create -c collection1 &&\
+    solr create -c metal_store &&\
+    solr create -c myfiles &&\
+    curl 'http://localhost:8983/solr/collection1/update/json?commit=true' --data-binary @collections/collection1.json -H 'Content-type:application/json' &&\
+    curl 'http://localhost:8983/solr/metal_store/update/json?commit=true' --data-binary @collections/metal_store.json -H 'Content-type:application/json' &&\
+    solr stop

--- a/tests/docker/collections/collection1.json
+++ b/tests/docker/collections/collection1.json
@@ -1,0 +1,698 @@
+[
+  {
+    "id": "GB18030TEST",
+    "name": [
+      "Test with some GB18030 encoded characters"
+    ],
+    "features": [
+      "No accents here",
+      "这是一个功能",
+      "This is a feature (translated)",
+      "这份文件是很有光泽",
+      "This document is very shiny (translated)"
+    ],
+    "price": [
+      0
+    ],
+    "inStock": [
+      true
+    ]
+  },
+  {
+    "id": "SP2514N",
+    "name": [
+      "Samsung SpinPoint P120 SP2514N - hard drive - 250 GB - ATA-133"
+    ],
+    "manu": [
+      "Samsung Electronics Co. Ltd."
+    ],
+    "manu_id_s": "samsung",
+    "cat": [
+      "electronics",
+      "hard drive"
+    ],
+    "features": [
+      "7200RPM, 8MB cache, IDE Ultra ATA-133",
+      "NoiseGuard, SilentSeek technology, Fluid Dynamic Bearing (FDB) motor"
+    ],
+    "price": [
+      92
+    ],
+    "popularity": [
+      6
+    ],
+    "inStock": [
+      true
+    ],
+    "manufacturedate_dt": "2006-02-13T15:26:37Z",
+    "store": [
+      "35.0752,-97.032"
+    ]
+  },
+  {
+    "id": "6H500F0",
+    "name": [
+      "Maxtor DiamondMax 11 - hard drive - 500 GB - SATA-300"
+    ],
+    "manu": [
+      "Maxtor Corp."
+    ],
+    "manu_id_s": "maxtor",
+    "cat": [
+      "electronics",
+      "hard drive"
+    ],
+    "features": [
+      "SATA 3.0Gb/s, NCQ",
+      "8.5ms seek",
+      "16MB cache"
+    ],
+    "price": [
+      350
+    ],
+    "popularity": [
+      6
+    ],
+    "inStock": [
+      true
+    ],
+    "store": [
+      "45.17614,-93.87341"
+    ],
+    "manufacturedate_dt": "2006-02-13T15:26:37Z"
+  },
+  {
+    "id": "F8V7067-APL-KIT",
+    "name": [
+      "Belkin Mobile Power Cord for iPod w/ Dock"
+    ],
+    "manu": [
+      "Belkin"
+    ],
+    "manu_id_s": "belkin",
+    "cat": [
+      "electronics",
+      "connector"
+    ],
+    "features": [
+      "car power adapter, white"
+    ],
+    "weight": [
+      4
+    ],
+    "price": [
+      19.95
+    ],
+    "popularity": [
+      1
+    ],
+    "inStock": [
+      false
+    ],
+    "store": [
+      "45.18014,-93.87741"
+    ],
+    "manufacturedate_dt": "2005-08-01T16:30:25Z"
+  },
+  {
+    "id": "IW-02",
+    "name": [
+      "iPod & iPod Mini USB 2.0 Cable"
+    ],
+    "manu": [
+      "Belkin"
+    ],
+    "manu_id_s": "belkin",
+    "cat": [
+      "electronics",
+      "connector"
+    ],
+    "features": [
+      "car power adapter for iPod, white"
+    ],
+    "weight": [
+      2
+    ],
+    "price": [
+      11.5
+    ],
+    "popularity": [
+      1
+    ],
+    "inStock": [
+      false
+    ],
+    "store": [
+      "37.7752,-122.4232"
+    ],
+    "manufacturedate_dt": "2006-02-14T23:55:59Z"
+  },
+  {
+    "id": "MA147LL/A",
+    "name": [
+      "Apple 60 GB iPod with Video Playback Black"
+    ],
+    "manu": [
+      "Apple Computer Inc."
+    ],
+    "manu_id_s": "apple",
+    "cat": [
+      "electronics",
+      "music"
+    ],
+    "features": [
+      "iTunes, Podcasts, Audiobooks",
+      "Stores up to 15,000 songs, 25,000 photos, or 150 hours of video",
+      "2.5-inch, 320x240 color TFT LCD display with LED backlight",
+      "Up to 20 hours of battery life",
+      "Plays AAC, MP3, WAV, AIFF, Audible, Apple Lossless, H.264 video",
+      "Notes, Calendar, Phone book, Hold button, Date display, Photo wallet, Built-in games, JPEG photo playback, Upgradeable firmware, USB 2.0 compatibility, Playback speed control, Rechargeable capability, Battery level indication"
+    ],
+    "includes": [
+      "earbud headphones, USB cable"
+    ],
+    "weight": [
+      5.5
+    ],
+    "price": [
+      399
+    ],
+    "popularity": [
+      10
+    ],
+    "inStock": [
+      true
+    ],
+    "store": [
+      "37.7752,-100.0232"
+    ],
+    "manufacturedate_dt": "2005-10-12T08:00:00Z"
+  },
+  {
+    "id": "adata",
+    "compName_s": "A-Data Technology",
+    "address_s": "46221 Landing Parkway Fremont, CA 94538"
+  },
+  {
+    "id": "apple",
+    "compName_s": "Apple",
+    "address_s": "1 Infinite Way, Cupertino CA"
+  },
+  {
+    "id": "asus",
+    "compName_s": "ASUS Computer",
+    "address_s": "800 Corporate Way Fremont, CA 94539"
+  },
+  {
+    "id": "ati",
+    "compName_s": "ATI Technologies",
+    "address_s": "33 Commerce Valley Drive East Thornhill, ON L3T 7N6 Canada"
+  },
+  {
+    "id": "belkin",
+    "compName_s": "Belkin",
+    "address_s": "12045 E. Waterfront Drive Playa Vista, CA 90094"
+  },
+  {
+    "id": "canon",
+    "compName_s": "Canon, Inc.",
+    "address_s": "One Canon Plaza Lake Success, NY 11042"
+  },
+  {
+    "id": "corsair",
+    "compName_s": "Corsair Microsystems",
+    "address_s": "46221 Landing Parkway Fremont, CA 94538"
+  },
+  {
+    "id": "dell",
+    "compName_s": "Dell, Inc.",
+    "address_s": "One Dell Way Round Rock, Texas 78682"
+  },
+  {
+    "id": "maxtor",
+    "compName_s": "Maxtor Corporation",
+    "address_s": "920 Disc Drive Scotts Valley, CA 95066"
+  },
+  {
+    "id": "samsung",
+    "compName_s": "Samsung Electronics Co. Ltd.",
+    "address_s": "105 Challenger Rd. Ridgefield Park, NJ 07660-0511"
+  },
+  {
+    "id": "viewsonic",
+    "compName_s": "ViewSonic Corp",
+    "address_s": "381 Brea Canyon Road Walnut, CA 91789-0708"
+  },
+  {
+    "id": "TWINX2048-3200PRO",
+    "name": [
+      "CORSAIR  XMS 2GB (2 x 1GB) 184-Pin DDR SDRAM Unbuffered DDR 400 (PC 3200) Dual Channel Kit System Memory - Retail"
+    ],
+    "manu": [
+      "Corsair Microsystems Inc."
+    ],
+    "manu_id_s": "corsair",
+    "cat": [
+      "electronics",
+      "memory"
+    ],
+    "features": [
+      "CAS latency 2,\t2-3-3-6 timing, 2.75v, unbuffered, heat-spreader"
+    ],
+    "price": [
+      185
+    ],
+    "popularity": [
+      5
+    ],
+    "inStock": [
+      true
+    ],
+    "store": [
+      "37.7752,-122.4232"
+    ],
+    "manufacturedate_dt": "2006-02-13T15:26:37Z",
+    "payloads": [
+      "electronics|6.0 memory|3.0"
+    ]
+  },
+  {
+    "id": "VS1GB400C3",
+    "name": [
+      "CORSAIR ValueSelect 1GB 184-Pin DDR SDRAM Unbuffered DDR 400 (PC 3200) System Memory - Retail"
+    ],
+    "manu": [
+      "Corsair Microsystems Inc."
+    ],
+    "manu_id_s": "corsair",
+    "cat": [
+      "electronics",
+      "memory"
+    ],
+    "price": [
+      74.99
+    ],
+    "popularity": [
+      7
+    ],
+    "inStock": [
+      true
+    ],
+    "store": [
+      "37.7752,-100.0232"
+    ],
+    "manufacturedate_dt": "2006-02-13T15:26:37Z",
+    "payloads": [
+      "electronics|4.0 memory|2.0"
+    ]
+  },
+  {
+    "id": "VDBDB1A16",
+    "name": [
+      "A-DATA V-Series 1GB 184-Pin DDR SDRAM Unbuffered DDR 400 (PC 3200) System Memory - OEM"
+    ],
+    "manu": [
+      "A-DATA Technology Inc."
+    ],
+    "manu_id_s": "corsair",
+    "cat": [
+      "electronics",
+      "memory"
+    ],
+    "features": [
+      "CAS latency 3,\t 2.7v"
+    ],
+    "popularity": [
+      0
+    ],
+    "inStock": [
+      true
+    ],
+    "store": [
+      "45.18414,-93.88141"
+    ],
+    "manufacturedate_dt": "2006-02-13T15:26:37Z",
+    "payloads": [
+      "electronics|0.9 memory|0.1"
+    ]
+  },
+  {
+    "id": "USD",
+    "name": [
+      "One Dollar"
+    ],
+    "manu": [
+      "Bank of America"
+    ],
+    "manu_id_s": "boa",
+    "cat": [
+      "currency"
+    ],
+    "features": [
+      "Coins and notes"
+    ],
+    "price_c": "1,USD",
+    "inStock": [
+      true
+    ]
+  },
+  {
+    "id": "EUR",
+    "name": [
+      "One Euro"
+    ],
+    "manu": [
+      "European Union"
+    ],
+    "manu_id_s": "eu",
+    "cat": [
+      "currency"
+    ],
+    "features": [
+      "Coins and notes"
+    ],
+    "price_c": "1,EUR",
+    "inStock": [
+      true
+    ]
+  },
+  {
+    "id": "GBP",
+    "name": [
+      "One British Pound"
+    ],
+    "manu": [
+      "U.K."
+    ],
+    "manu_id_s": "uk",
+    "cat": [
+      "currency"
+    ],
+    "features": [
+      "Coins and notes"
+    ],
+    "price_c": "1,GBP",
+    "inStock": [
+      true
+    ]
+  },
+  {
+    "id": "NOK",
+    "name": [
+      "One Krone"
+    ],
+    "manu": [
+      "Bank of Norway"
+    ],
+    "manu_id_s": "nor",
+    "cat": [
+      "currency"
+    ],
+    "features": [
+      "Coins and notes"
+    ],
+    "price_c": "1,NOK",
+    "inStock": [
+      true
+    ]
+  },
+  {
+    "id": "3007WFP",
+    "name": [
+      "Dell Widescreen UltraSharp 3007WFP"
+    ],
+    "manu": [
+      "Dell, Inc."
+    ],
+    "manu_id_s": "dell",
+    "cat": [
+      "electronics and computer1"
+    ],
+    "features": [
+      "30\" TFT active matrix LCD, 2560 x 1600, .25mm dot pitch, 700:1 contrast"
+    ],
+    "includes": [
+      "USB cable"
+    ],
+    "weight": [
+      401.6
+    ],
+    "price": [
+      2199
+    ],
+    "popularity": [
+      6
+    ],
+    "inStock": [
+      true
+    ],
+    "store": [
+      "43.17614,-90.57341"
+    ]
+  },
+  {
+    "id": "VA902B",
+    "name": [
+      "ViewSonic VA902B - flat panel display - TFT - 19\""
+    ],
+    "manu": [
+      "ViewSonic Corp."
+    ],
+    "manu_id_s": "viewsonic",
+    "cat": [
+      "electronics and stuff2"
+    ],
+    "features": [
+      "19\" TFT active matrix LCD, 8ms response time, 1280 x 1024 native resolution"
+    ],
+    "weight": [
+      190.4
+    ],
+    "price": [
+      279.95
+    ],
+    "popularity": [
+      6
+    ],
+    "inStock": [
+      true
+    ],
+    "store": [
+      "45.18814,-93.88541"
+    ]
+  },
+  {
+    "id": "0579B002",
+    "name": [
+      "Canon PIXMA MP500 All-In-One Photo Printer"
+    ],
+    "manu": [
+      "Canon Inc."
+    ],
+    "manu_id_s": "canon",
+    "cat": [
+      "electronics",
+      "multifunction printer",
+      "printer",
+      "scanner",
+      "copier"
+    ],
+    "features": [
+      "Multifunction ink-jet color photo printer",
+      "Flatbed scanner, optical scan resolution of 1,200 x 2,400 dpi",
+      "2.5\" color LCD preview screen",
+      "Duplex Copying",
+      "Printing speed up to 29ppm black, 19ppm color",
+      "Hi-Speed USB",
+      "memory card: CompactFlash, Micro Drive, SmartMedia, Memory Stick, Memory Stick Pro, SD Card, and MultiMediaCard"
+    ],
+    "weight": [
+      352
+    ],
+    "price": [
+      179.99
+    ],
+    "popularity": [
+      6
+    ],
+    "inStock": [
+      true
+    ],
+    "store": [
+      "45.19214,-93.89941"
+    ]
+  },
+  {
+    "id": "9885A004",
+    "name": [
+      "Canon PowerShot SD500"
+    ],
+    "manu": [
+      "Canon Inc."
+    ],
+    "manu_id_s": "canon",
+    "cat": [
+      "electronics",
+      "camera"
+    ],
+    "features": [
+      "3x zoop, 7.1 megapixel Digital ELPH",
+      "movie clips up to 640x480 @30 fps",
+      "2.0\" TFT LCD, 118,000 pixels",
+      "built in flash, red-eye reduction"
+    ],
+    "includes": [
+      "32MB SD card, USB cable, AV cable, battery"
+    ],
+    "weight": [
+      6.4
+    ],
+    "price": [
+      329.95
+    ],
+    "popularity": [
+      7
+    ],
+    "inStock": [
+      true
+    ],
+    "manufacturedate_dt": "2006-02-13T15:26:37Z",
+    "store": [
+      "45.19614,-93.90341"
+    ]
+  },
+  {
+    "id": "SOLR1000",
+    "name": [
+      "Solr, the Enterprise Search Server"
+    ],
+    "manu": [
+      "Apache Software Foundation"
+    ],
+    "cat": [
+      "software",
+      "search"
+    ],
+    "features": [
+      "Advanced Full-Text Search Capabilities using Lucene",
+      "Optimized for High Volume Web Traffic",
+      "Standards Based Open Interfaces - XML and HTTP",
+      "Comprehensive HTML Administration Interfaces",
+      "Scalability - Efficient Replication to other Solr Search Servers",
+      "Flexible and Adaptable with XML configuration and Schema",
+      "Good unicode support: héllo (hello with an accent over the e)"
+    ],
+    "price": [
+      0
+    ],
+    "popularity": [
+      10
+    ],
+    "inStock": [
+      true
+    ],
+    "incubationdate_dt": "2006-01-17T00:00:00Z"
+  },
+  {
+    "id": "UTF8TEST",
+    "name": [
+      "Test with some UTF-8 encoded characters"
+    ],
+    "manu": [
+      "Apache Software Foundation"
+    ],
+    "cat": [
+      "software",
+      "search"
+    ],
+    "features": [
+      "No accents here",
+      "This is an e acute: é",
+      "eaiou with circumflexes: êâîôû",
+      "eaiou with umlauts: ëäïöü",
+      "tag with escaped chars: <nicetag/>",
+      "escaped ampersand: Bonnie & Clyde",
+      "Outside the BMP:𐌈 codepoint=10308, a circle with an x inside. UTF8=f0908c88 UTF16=d800 df08"
+    ],
+    "price": [
+      0
+    ],
+    "inStock": [
+      true
+    ]
+  },
+  {
+    "id": "EN7800GTX/2DHTV/256M",
+    "name": [
+      "ASUS Extreme N7800GTX/2DHTV (256 MB)"
+    ],
+    "manu": [
+      "ASUS Computer Inc."
+    ],
+    "manu_id_s": "asus",
+    "cat": [
+      "electronics",
+      "graphics card"
+    ],
+    "features": [
+      "NVIDIA GeForce 7800 GTX GPU/VPU clocked at 486MHz",
+      "256MB GDDR3 Memory clocked at 1.35GHz",
+      "PCI Express x16",
+      "Dual DVI connectors, HDTV out, video input",
+      "OpenGL 2.0, DirectX 9.0"
+    ],
+    "weight": [
+      16
+    ],
+    "price": [
+      479.95
+    ],
+    "popularity": [
+      7
+    ],
+    "store": [
+      "40.7143,-74.006"
+    ],
+    "inStock": [
+      false
+    ],
+    "manufacturedate_dt": "2006-02-13T00:00:00Z"
+  },
+  {
+    "id": "100-435805",
+    "name": [
+      "ATI Radeon X1900 XTX 512 MB PCIE Video Card"
+    ],
+    "manu": [
+      "ATI Technologies"
+    ],
+    "manu_id_s": "ati",
+    "cat": [
+      "electronics",
+      "graphics card"
+    ],
+    "features": [
+      "ATI RADEON X1900 GPU/VPU clocked at 650MHz",
+      "512MB GDDR3 SDRAM clocked at 1.55GHz",
+      "PCI Express x16",
+      "dual DVI, HDTV, svideo, composite out",
+      "OpenGL 2.0, DirectX 9.0"
+    ],
+    "weight": [
+      48
+    ],
+    "price": [
+      649.99
+    ],
+    "popularity": [
+      7
+    ],
+    "inStock": [
+      false
+    ],
+    "manufacturedate_dt": "2006-02-13T00:00:00Z",
+    "store": [
+      "40.7143,-74.006"
+    ]
+  }
+]

--- a/tests/docker/collections/metal_store.json
+++ b/tests/docker/collections/metal_store.json
@@ -1,0 +1,92 @@
+[
+  {
+    "id": "IMM-HOW-S",
+    "size_s": "small",
+    "inventory_i": 200,
+    "content_type_s": "sku"
+  },
+  {
+    "id": "IMM-HOW-M",
+    "size_s": "medium",
+    "inventory_i": 120,
+    "content_type_s": "sku"
+  },
+  {
+    "id": "IMM-HOW-L",
+    "size_s": "large",
+    "inventory_i": 100,
+    "content_type_s": "sku"
+  },
+  {
+    "id": "IMM-HOW-XL",
+    "size_s": "xlarge",
+    "inventory_i": 50,
+    "content_type_s": "sku"
+  },
+  {
+    "id": "1",
+    "name_s": "Immortal - At the heart of winter",
+    "cat": [
+      "tops",
+      "tshirts"
+    ],
+    "artist_s": "Immortal",
+    "content_type_s": "product"
+  },
+  {
+    "id": "KOR-SOF-M",
+    "size_s": "medium",
+    "inventory_i": 120,
+    "content_type_s": "sku"
+  },
+  {
+    "id": "KOR-SOF-L",
+    "size_s": "large",
+    "inventory_i": 100,
+    "content_type_s": "sku"
+  },
+  {
+    "id": "KOR-SOF-XL",
+    "size_s": "xlarge",
+    "inventory_i": 50,
+    "content_type_s": "sku"
+  },
+  {
+    "id": "2",
+    "name_s": "Korpiklaani - Spirit Of the Forest",
+    "artist_s": "Korpiklaani",
+    "cat": [
+      "tops",
+      "tshirts"
+    ],
+    "content_type_s": "product"
+  },
+  {
+    "id": "SATY-ND-M",
+    "size_s": "medium",
+    "inventory_i": 120,
+    "content_type_s": "sku"
+  },
+  {
+    "id": "SATY-ND-L",
+    "size_s": "large",
+    "inventory_i": 100,
+    "content_type_s": "sku"
+  },
+  {
+    "id": "SATY-ND-XL",
+    "size_s": "xlarge",
+    "inventory_i": 50,
+    "content_type_s": "sku"
+  },
+  {
+    "id": "3",
+    "name_s": "Satyricon - Nemesis Divina",
+    "artist_s": "Satyricon",
+    "cat": [
+      "tops",
+      "tshirts"
+    ],
+    "content_type_s": "product"
+  }
+]

--- a/tests/docker/collections/metal_store.json
+++ b/tests/docker/collections/metal_store.json
@@ -1,29 +1,5 @@
 [
   {
-    "id": "IMM-HOW-S",
-    "size_s": "small",
-    "inventory_i": 200,
-    "content_type_s": "sku"
-  },
-  {
-    "id": "IMM-HOW-M",
-    "size_s": "medium",
-    "inventory_i": 120,
-    "content_type_s": "sku"
-  },
-  {
-    "id": "IMM-HOW-L",
-    "size_s": "large",
-    "inventory_i": 100,
-    "content_type_s": "sku"
-  },
-  {
-    "id": "IMM-HOW-XL",
-    "size_s": "xlarge",
-    "inventory_i": 50,
-    "content_type_s": "sku"
-  },
-  {
     "id": "1",
     "name_s": "Immortal - At the heart of winter",
     "cat": [
@@ -31,25 +7,37 @@
       "tshirts"
     ],
     "artist_s": "Immortal",
-    "content_type_s": "product"
-  },
-  {
-    "id": "KOR-SOF-M",
-    "size_s": "medium",
-    "inventory_i": 120,
-    "content_type_s": "sku"
-  },
-  {
-    "id": "KOR-SOF-L",
-    "size_s": "large",
-    "inventory_i": 100,
-    "content_type_s": "sku"
-  },
-  {
-    "id": "KOR-SOF-XL",
-    "size_s": "xlarge",
-    "inventory_i": 50,
-    "content_type_s": "sku"
+    "content_type_s": "product",
+    "_childDocuments_": [
+      {
+        "id": "IMM-HOW-S",
+        "size_s": "small",
+        "inventory_i": 200,
+        "content_type_s": "sku",
+        "_version_": 1756623851107647500
+      },
+      {
+        "id": "IMM-HOW-M",
+        "size_s": "medium",
+        "inventory_i": 120,
+        "content_type_s": "sku",
+        "_version_": 1756623851109744600
+      },
+      {
+        "id": "IMM-HOW-L",
+        "size_s": "large",
+        "inventory_i": 100,
+        "content_type_s": "sku",
+        "_version_": 1756623851109744600
+      },
+      {
+        "id": "IMM-HOW-XL",
+        "size_s": "xlarge",
+        "inventory_i": 50,
+        "content_type_s": "sku",
+        "_version_": 1756623851110793200
+      }
+    ]
   },
   {
     "id": "2",
@@ -59,25 +47,27 @@
       "tops",
       "tshirts"
     ],
-    "content_type_s": "product"
-  },
-  {
-    "id": "SATY-ND-M",
-    "size_s": "medium",
-    "inventory_i": 120,
-    "content_type_s": "sku"
-  },
-  {
-    "id": "SATY-ND-L",
-    "size_s": "large",
-    "inventory_i": 100,
-    "content_type_s": "sku"
-  },
-  {
-    "id": "SATY-ND-XL",
-    "size_s": "xlarge",
-    "inventory_i": 50,
-    "content_type_s": "sku"
+    "content_type_s": "product",
+    "_childDocuments_": [
+      {
+        "id": "KOR-SOF-M",
+        "size_s": "medium",
+        "inventory_i": 120,
+        "content_type_s": "sku"
+      },
+      {
+        "id": "KOR-SOF-L",
+        "size_s": "large",
+        "inventory_i": 100,
+        "content_type_s": "sku"
+      },
+      {
+        "id": "KOR-SOF-XL",
+        "size_s": "xlarge",
+        "inventory_i": 50,
+        "content_type_s": "sku"
+      }
+    ]
   },
   {
     "id": "3",
@@ -87,6 +77,26 @@
       "tops",
       "tshirts"
     ],
-    "content_type_s": "product"
+    "content_type_s": "product",
+    "_childDocuments_": [
+      {
+        "id": "SATY-ND-M",
+        "size_s": "medium",
+        "inventory_i": 120,
+        "content_type_s": "sku"
+      },
+      {
+        "id": "SATY-ND-L",
+        "size_s": "large",
+        "inventory_i": 100,
+        "content_type_s": "sku"
+      },
+      {
+        "id": "SATY-ND-XL",
+        "size_s": "xlarge",
+        "inventory_i": 50,
+        "content_type_s": "sku"
+      }
+    ]
   }
 ]


### PR DESCRIPTION
# Add GitHub CI pipeline for tests

This PR adds a workflow under `.github/workflows` to run all the tests (`make test`) whenever a commit or a pull request is made. It tests multiple PHP versions from 7.2 to 8.2 in a matrix using an Ubuntu runner.

To run the tests, a Solr service container has to be started on the side. I added a Dockerfile under `tests/docker` that is based on Omar's image but uses a newer Solr version (5.3 -> 6.3) and has been published to Docker Hub as `stefna/pecl-solr`.

I also added small fixes to some tests that were hardcoded to use `localhost:8983` as host, and the getRawHeaders test had to be updated as Solr 6.3 returns slightly different headers.