### PR TITLE
Fix solr query types

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,2 +1,3 @@
 - Fix compile error: libcurl on linux multiarch support (#46)
 - Fix SegFault in SolrClient::optimize() (debug mode)
+- Fix parsed parameter types (#37)

--- a/src/php7/php_solr_collapse_function.c
+++ b/src/php7/php_solr_collapse_function.c
@@ -178,10 +178,22 @@ PHP_METHOD(SolrCollapseFunction, setSize)
 {
     solr_char_t *key = "size", *arg;
     COMPAT_ARG_SIZE_T  key_len = sizeof("size"), arg_len;
+    zval *tmp;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS(), "s", &arg, &arg_len) == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "z", &tmp) == FAILURE) {
         RETURN_NULL();
     }
+
+    if (Z_TYPE_P(tmp) == IS_LONG) {
+	convert_to_string(tmp);
+    }
+
+    if (Z_TYPE_P(tmp) != IS_STRING) {
+	solr_throw_exception(solr_ce_SolrIllegalArgumentException, "Argument 1 must be an int", SOLR_ERROR_4000, SOLR_FILE_LINE_FUNC);
+    }
+
+    arg = Z_STRVAL_P(tmp);
+    arg_len = Z_STRLEN_P(tmp);
 
     if (solr_solrfunc_update_string(getThis(), key, key_len, (solr_char_t *)arg, arg_len) == FAILURE) {
         php_error_docref(NULL, E_ERROR, "Error assigning field");

--- a/src/php7/php_solr_dismax_query.c
+++ b/src/php7/php_solr_dismax_query.c
@@ -429,12 +429,25 @@ PHP_METHOD(SolrDisMaxQuery, setPhraseSlop)
     int add_result = -1;
     solr_char_t *pvalue = NULL;
     COMPAT_ARG_SIZE_T pvalue_len = 0;
+    zval *tmp;
 
-    if(zend_parse_parameters(ZEND_NUM_ARGS(), "s", &pvalue, &pvalue_len) == FAILURE)
+    if(zend_parse_parameters(ZEND_NUM_ARGS(), "z", &tmp) == FAILURE)
     {
         php_error_docref(NULL, E_WARNING, "Invalid parameters");
         RETURN_NULL();
     }
+
+    if (Z_TYPE_P(tmp) == IS_LONG) {
+	convert_to_string(tmp);
+    }
+
+    if (Z_TYPE_P(tmp) != IS_STRING) {
+        solr_throw_exception(solr_ce_SolrIllegalArgumentException, "Argument 1 must be an int", SOLR_ERROR_4000, SOLR_FILE_LINE_FUNC);
+    }
+
+    pvalue = Z_STRVAL_P(tmp);
+    pvalue_len = Z_STRLEN_P(tmp);
+
     add_result = solr_add_or_set_normal_param(getThis(), pname, pname_len, pvalue, pvalue_len, 0);
 
     if(add_result == FAILURE)
@@ -455,12 +468,25 @@ PHP_METHOD(SolrDisMaxQuery, setQueryPhraseSlop)
     int add_result = -1;
     solr_char_t *pvalue = NULL;
     COMPAT_ARG_SIZE_T pvalue_len = 0;
+    zval *tmp;
 
-    if(zend_parse_parameters(ZEND_NUM_ARGS(), "s", &pvalue, &pvalue_len) == FAILURE)
+    if(zend_parse_parameters(ZEND_NUM_ARGS(), "z", &tmp) == FAILURE)
     {
         php_error_docref(NULL, E_WARNING, "Invalid parameters");
         RETURN_NULL();
     }
+
+    if (Z_TYPE_P(tmp) == IS_LONG) {
+	convert_to_string(tmp);
+    }
+
+    if (Z_TYPE_P(tmp) != IS_STRING) {
+        solr_throw_exception(solr_ce_SolrIllegalArgumentException, "Argument 1 must be an int", SOLR_ERROR_4000, SOLR_FILE_LINE_FUNC);
+    }
+
+    pvalue = Z_STRVAL_P(tmp);
+    pvalue_len = Z_STRLEN_P(tmp);
+
     add_result = solr_add_or_set_normal_param(getThis(), pname, pname_len, pvalue, pvalue_len, 0);
 
     if(add_result == FAILURE)
@@ -774,12 +800,25 @@ PHP_METHOD(SolrDisMaxQuery, setBigramPhraseSlop)
     int add_result = -1;
     solr_char_t *pvalue = NULL;
     COMPAT_ARG_SIZE_T pvalue_len = 0;
+    zval *tmp;
 
-    if(zend_parse_parameters(ZEND_NUM_ARGS(), "s", &pvalue, &pvalue_len) == FAILURE)
+    if(zend_parse_parameters(ZEND_NUM_ARGS(), "z", &tmp) == FAILURE)
     {
         php_error_docref(NULL, E_WARNING, "Invalid parameters");
         RETURN_NULL();
     }
+
+    if (Z_TYPE_P(tmp) == IS_LONG) {
+	convert_to_string(tmp);
+    }
+
+    if (Z_TYPE_P(tmp) != IS_STRING) {
+        solr_throw_exception(solr_ce_SolrIllegalArgumentException, "Argument 1 must be an int", SOLR_ERROR_4000, SOLR_FILE_LINE_FUNC);
+    }
+
+    pvalue = Z_STRVAL_P(tmp);
+    pvalue_len = Z_STRLEN_P(tmp);
+
     add_result = solr_add_or_set_normal_param(getThis(), pname, pname_len, pvalue, pvalue_len, 0);
 
     if(add_result == FAILURE)
@@ -883,12 +922,25 @@ PHP_METHOD(SolrDisMaxQuery, setTrigramPhraseSlop)
     int add_result = -1;
     solr_char_t *pvalue = NULL;
     COMPAT_ARG_SIZE_T pvalue_len = 0;
+    zval *tmp;
 
-    if(zend_parse_parameters(ZEND_NUM_ARGS(), "s", &pvalue, &pvalue_len) == FAILURE)
+    if(zend_parse_parameters(ZEND_NUM_ARGS(), "z", &tmp) == FAILURE)
     {
         php_error_docref(NULL, E_WARNING, "Invalid parameters");
         RETURN_NULL();
     }
+
+    if (Z_TYPE_P(tmp) == IS_LONG) {
+	convert_to_string(tmp);
+    }
+
+    if (Z_TYPE_P(tmp) != IS_STRING) {
+        solr_throw_exception(solr_ce_SolrIllegalArgumentException, "Argument 1 must be an int", SOLR_ERROR_4000, SOLR_FILE_LINE_FUNC);
+    }
+
+    pvalue = Z_STRVAL_P(tmp);
+    pvalue_len = Z_STRLEN_P(tmp);
+
     add_result = solr_add_or_set_normal_param(getThis(), pname, pname_len, pvalue, pvalue_len, 0);
 
     if(add_result == FAILURE)

--- a/src/php7/php_solr_query.c
+++ b/src/php7/php_solr_query.c
@@ -130,13 +130,26 @@ PHP_METHOD(SolrQuery, setStart)
 	COMPAT_ARG_SIZE_T param_name_len = sizeof("start")-1;
 	solr_char_t *param_value = NULL;
 	COMPAT_ARG_SIZE_T param_value_len = 0;
+	zval *tmp;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s", &param_value, &param_value_len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "z", &tmp) == FAILURE) {
 
 		php_error_docref(NULL, E_WARNING, "Invalid parameters");
 
 		RETURN_NULL();
 	}
+
+	if (Z_TYPE_P(tmp) == IS_LONG) {
+		convert_to_string(tmp);
+	}
+
+	if (Z_TYPE_P(tmp) != IS_STRING) {
+		solr_throw_exception(solr_ce_SolrIllegalArgumentException, "Argument 1 must be an int", SOLR_ERROR_4000, SOLR_FILE_LINE_FUNC);
+		RETURN_NULL();
+	}
+
+	param_value = Z_STRVAL_P(tmp);
+	param_value_len = Z_STRLEN_P(tmp);
 
 	if (solr_set_normal_param(getThis(), param_name, param_name_len, param_value, param_value_len) == FAILURE)
 	{
@@ -155,13 +168,26 @@ PHP_METHOD(SolrQuery, setRows)
 	COMPAT_ARG_SIZE_T param_name_len = sizeof("rows")-1;
 	solr_char_t *param_value = NULL;
 	COMPAT_ARG_SIZE_T param_value_len = 0;
+	zval *tmp = NULL;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s", &param_value, &param_value_len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "z", &tmp) == FAILURE) {
 
 		php_error_docref(NULL, E_WARNING, "Invalid parameters");
 
 		RETURN_NULL();
 	}
+
+	if (Z_TYPE_P(tmp) == IS_LONG) {
+		convert_to_string(tmp);
+	}
+
+	if (Z_TYPE_P(tmp) != IS_STRING) {
+		solr_throw_exception(solr_ce_SolrIllegalArgumentException, "Argument 1 must be an int", SOLR_ERROR_4000, SOLR_FILE_LINE_FUNC);
+		RETURN_NULL();
+	}
+
+	param_value = Z_STRVAL_P(tmp);
+	param_value_len = Z_STRLEN_P(tmp);
 
 	if (solr_set_normal_param(getThis(), param_name, param_name_len, param_value, param_value_len) == FAILURE)
 	{
@@ -326,13 +352,26 @@ PHP_METHOD(SolrQuery, setTimeAllowed)
 	COMPAT_ARG_SIZE_T param_name_len = sizeof("timeAllowed")-1;
 	solr_char_t *param_value = NULL;
 	COMPAT_ARG_SIZE_T param_value_len = 0;
+	zval *tmp = NULL;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s", &param_value, &param_value_len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "z", &tmp) == FAILURE) {
 
 		php_error_docref(NULL, E_WARNING, "Invalid parameters");
 
 		RETURN_NULL();
 	}
+
+	if (Z_TYPE_P(tmp) == IS_LONG) {
+		convert_to_string(tmp);
+	}
+
+	if (Z_TYPE_P(tmp) != IS_STRING) {
+		solr_throw_exception(solr_ce_SolrIllegalArgumentException, "Argument 1 must be an int", SOLR_ERROR_4000, SOLR_FILE_LINE_FUNC);
+		RETURN_NULL();
+	}
+
+	param_value = Z_STRVAL_P(tmp);
+	param_value_len = Z_STRLEN_P(tmp);
 
 	if (solr_set_normal_param(getThis(), param_name, param_name_len, param_value, param_value_len) == FAILURE)
 	{
@@ -1343,13 +1382,26 @@ PHP_METHOD(SolrQuery, setGroupOffset)
 	int param_name_len = sizeof("group.offset")-1;
 	solr_char_t *param_value = NULL;
 	COMPAT_ARG_SIZE_T  param_value_len = 0;
+	zval *tmp = NULL;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s", &param_value, &param_value_len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "z", &tmp) == FAILURE) {
 
 		php_error_docref(NULL, E_WARNING, "Invalid parameters");
 
 		RETURN_NULL();
 	}
+
+	if (Z_TYPE_P(tmp) == IS_LONG) {
+		convert_to_string(tmp);
+	}
+
+	if (Z_TYPE_P(tmp) != IS_STRING) {
+		solr_throw_exception(solr_ce_SolrIllegalArgumentException, "Argument 1 must be an int", SOLR_ERROR_4000, SOLR_FILE_LINE_FUNC);
+		RETURN_NULL();
+	}
+
+	param_value = Z_STRVAL_P(tmp);
+	param_value_len = Z_STRLEN_P(tmp);
 
 	if (solr_add_normal_param(getThis(), param_name, param_name_len, param_value, param_value_len) == FAILURE)
 	{
@@ -1917,13 +1969,26 @@ PHP_METHOD(SolrQuery, setExpandRows)
     COMPAT_ARG_SIZE_T param_name_len = sizeof("expand.rows")-1;
     solr_char_t *param_value = NULL;
     COMPAT_ARG_SIZE_T param_value_len = 0;
+	zval *tmp = NULL;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS(), "s", &param_value, &param_value_len) == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "z", &tmp) == FAILURE) {
 
         php_error_docref(NULL, E_WARNING, "Invalid parameters");
 
         RETURN_NULL();
     }
+
+	if (Z_TYPE_P(tmp) == IS_LONG) {
+		convert_to_string(tmp);
+	}
+
+	if (Z_TYPE_P(tmp) != IS_STRING) {
+		solr_throw_exception(solr_ce_SolrIllegalArgumentException, "Argument 1 must be an int", SOLR_ERROR_4000, SOLR_FILE_LINE_FUNC);
+		RETURN_NULL();
+	}
+
+	param_value = Z_STRVAL_P(tmp);
+	param_value_len = Z_STRLEN_P(tmp);
 
     if (solr_set_normal_param(getThis(), param_name, param_name_len, param_value, param_value_len) == FAILURE)
     {

--- a/tests/203.solrquery_strict_types.phpt
+++ b/tests/203.solrquery_strict_types.phpt
@@ -21,8 +21,11 @@ $query->setTimeAllowed('300');
 $query->setGroupOffset('1');
 $query->setExpandRows('1');
 
-echo $query;
+echo $query . "\n";
+
+try { $query->setStart(true); } catch (SolrIllegalArgumentException $e) { echo $e->getMessage(); }
 --EXPECT--
 q=lucene&start=1&rows=2&timeAllowed=300&group.offset=1&expand.rows=1
 q=lucene&start=1anystring&rows=2&timeAllowed=300&group.offset=1&expand.rows=1
+Argument 1 must be an int
 

--- a/tests/203.solrquery_strict_types.phpt
+++ b/tests/203.solrquery_strict_types.phpt
@@ -23,9 +23,25 @@ $query->setExpandRows('1');
 
 echo $query . "\n";
 
-try { $query->setStart(true); } catch (SolrIllegalArgumentException $e) { echo $e->getMessage(); }
+try { $query->setStart(true); } catch (SolrIllegalArgumentException $e) { echo $e->getMessage() . "\n"; }
+
+$collapse = new SolrCollapseFunction();
+$collapse->setSize(1);
+
+echo $collapse . "\n";
+
+$d = new SolrDisMaxQuery('lucene');
+$d->setPhraseSlop(2);
+$d->setQueryPhraseSlop(3);
+$d->setBigramPhraseSlop(4);
+$d->setTrigramPhraseSlop(5);
+
+echo $d . "\n";
+
 --EXPECT--
 q=lucene&start=1&rows=2&timeAllowed=300&group.offset=1&expand.rows=1
 q=lucene&start=1anystring&rows=2&timeAllowed=300&group.offset=1&expand.rows=1
 Argument 1 must be an int
+{!collapse size=1}
+q=lucene&defType=edismax&ps=2&qs=3&ps2=4&ps3=5
 

--- a/tests/203.solrquery_strict_types.phpt
+++ b/tests/203.solrquery_strict_types.phpt
@@ -1,0 +1,28 @@
+--TEST--
+SolrQuery - Strict type parameters without BC break
+--FILE--
+<?php declare(strict_types=1);
+
+$query = new SolrQuery('lucene');
+
+$query->setStart(1);
+$query->setRows(2);
+$query->setTimeAllowed(300);
+$query->setGroupOffset(1);
+$query->setExpandRows(1);
+
+echo $query . "\n";
+
+// Now with strings
+$query = new SolrQuery('lucene');
+$query->setStart('1anystring'); // we don't do any checking
+$query->setRows('2');
+$query->setTimeAllowed('300');
+$query->setGroupOffset('1');
+$query->setExpandRows('1');
+
+echo $query;
+--EXPECT--
+q=lucene&start=1&rows=2&timeAllowed=300&group.offset=1&expand.rows=1
+q=lucene&start=1anystring&rows=2&timeAllowed=300&group.offset=1&expand.rows=1
+


### PR DESCRIPTION
Fix for issue #37, attempt 3.

Previous: PR #38.

This time I manage to skip all BC problems, allowing both strings and integers.