### PR TITLE
Fix 019 getdebug test when response has "processing"

### DIFF
--- a/tests/019.solrclient_getdebug.phpt
+++ b/tests/019.solrclient_getdebug.phpt
@@ -33,7 +33,8 @@ foreach ( $lines as $line) {
 		0 === strpos($line, 'Hostname') ||
 		0 === strpos($line, 'TCP_NODELAY') || 
 		0 === strpos($line, 'Accept-Encoding') ||
-		0 === strpos($line, 'Curl_http_done')
+		0 === strpos($line, 'Curl_http_done') ||
+		0 === strpos($line, 'processing:')
 		) {
 		$print = false;
 	} else {


### PR DESCRIPTION
> Only a failed test (using `docker.io/omars/solr53` image for the server)
> 
> ```
> TEST 34/157 [tests/019.solrclient_getdebug.phpt]
> ========DIFF========
> --
>      Host: %s:%s
>      Keep-Alive: 300
>      User-Agent: %s
> 014+ processing: http://127.0.0.1:8983/solr/collection1/admin/ping/?version=2.2&indent=on&wt=xml
> ========DONE========
> FAIL SolrClient::getDebug() - Get request debug logs for the last request [tests/019.solrclient_getdebug.phpt] 
> ```

