### PR TITLE
simplify config.m4 as PHP 7.4 is required

### DIFF
--- a/README.INSTALLATION
+++ b/README.INSTALLATION
@@ -93,7 +93,6 @@ Then you can pass libcurl prefix to the configure script for CURL and LIBXML res
 during the configuration phase as shown here :
 
 export PKG_CONFIG_PATH=/root/custom/software/lib/pkgconfig
-export PATH=$PATH:/root/custom/software/bin
 ./configure --enable-solr
 
 If you already have the latest versions of the libraries then the step listed in 4A alone is sufficient.

--- a/config.m4
+++ b/config.m4
@@ -12,22 +12,7 @@ PHP_ARG_ENABLE(coverage, whether to enable code coverage,
 dnl Setting up the apache Solr extension
 if test "$PHP_SOLR" != "no"; then
 
-    AC_PATH_PROG(PKG_CONFIG, pkg-config, no)
-
-    AC_MSG_CHECKING(for libcurl)
-    if test -x "$PKG_CONFIG" && $PKG_CONFIG --exists libcurl; then
-      if $PKG_CONFIG libcurl --atleast-version 7.15.5; then
-        CURL_CFLAGS=`$PKG_CONFIG libcurl --cflags`
-        CURL_LIBS=`$PKG_CONFIG libcurl --libs`
-        CURL_VERSON=`$PKG_CONFIG libcurl --modversion`
-        AC_MSG_RESULT(from pkgconfig: version $CURL_VERSON found)
-      else
-        AC_MSG_ERROR(system libcurl must be upgraded to version >= 7.15.5)
-      fi
-    else
-      AC_MSG_ERROR(pkg-config or libcurl not found)
-    fi
-
+	PKG_CHECK_MODULES([CURL], [libcurl >= 7.15.5])
 	PHP_CHECK_LIBRARY(curl,curl_easy_perform,
     [
         AC_DEFINE(HAVE_CURL,1,[ ])
@@ -52,9 +37,8 @@ if test "$PHP_SOLR" != "no"; then
         AC_MSG_ERROR([Solr extension requires json or jsonc support])
     fi
 
-    dnl until PHP 7.3: xml2-config or pkg-config
-    dnl since PHP 7.4: pkg-config only
-	PHP_SETUP_LIBXML(SOLR_SHARED_LIBADD, [
+	PHP_SETUP_LIBXML(SOLR_SHARED_LIBADD)
+
     AC_DEFINE(HAVE_SOLR, 1,[Setting the value of HAVE_SOLR to 1 ])
 
     if test "$PHP_SOLR_DEBUG" != "no"; then
@@ -69,27 +53,10 @@ if test "$PHP_SOLR" != "no"; then
         EXTRA_LDFLAGS="$COVERAGE_CFLAGS"
     fi
 
-
     export OLD_CPPFLAGS="$CPPFLAGS"
     export CPPFLAGS="$CPPFLAGS $INCLUDES"
 
-    AC_MSG_CHECKING(PHP version)
-
-    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-    #include <php_version.h>
-    ]], [[
-#if PHP_MAJOR_VERSION > 5
-#error PHP > 5
-#endif
-    ]])],[
-    subdir=src/php5
-    AC_MSG_RESULT([PHP 5])
-    ],[
     subdir=src/php7
-    AC_MSG_RESULT([PHP 7])
-    ])
-
-
     PHP_SOLR_SRC_FILES="$subdir/php_solr.c \
                              $subdir/php_solr_object.c \
                              $subdir/php_solr_document.c \
@@ -115,7 +82,4 @@ if test "$PHP_SOLR" != "no"; then
     						 $ext_shared,, [$COVERAGE_CFLAGS])
     PHP_ADD_BUILD_DIR($abs_builddir/$subdir, 1)
     PHP_SUBST(SOLR_SHARED_LIBADD)
-  ], [
-    AC_MSG_ERROR([xml2-config not found. Please check your libxml2 installation.])
-  ])
 fi


### PR DESCRIPTION
* use PKG_CHECK_MODULES (php < 7.4 is not supported)
* cleanup PHP_SETUP_LIBXML (no need for dependent action, defaults are fine)
* cleanup PHP version check (php 5 is not supported for a long time)