### PR TITLE
Use AS_HELP_STRING for indented configure --help output

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -1,13 +1,22 @@
 dnl config.m4 for the solr extension
 
-PHP_ARG_ENABLE(solr, whether to enable the Solr extension,
-[  --enable-solr         Enable solr support])
+PHP_ARG_ENABLE([solr],
+  [whether to enable the Solr extension],
+  [AS_HELP_STRING([--enable-solr],
+    [Enable solr support])])
 
-PHP_ARG_ENABLE(solr-debug, whether to compile with solr in verbose mode,
-[  --enable-solr-debug          Compile with solr in verbose mode], no, no)
+PHP_ARG_ENABLE([solr-debug],
+  [whether to compile with solr in verbose mode],
+  [AS_HELP_STRING([--enable-solr-debug],
+    [Compile with solr in verbose mode])],
+  [no],
+  [no])
 
-PHP_ARG_ENABLE(coverage, whether to enable code coverage,
-    [  --enable-coverage Enable developer code coverage information],, no)
+PHP_ARG_ENABLE([coverage],
+  [whether to enable code coverage],
+  [AS_HELP_STRING([--enable-coverage],
+    [Enable developer code coverage information])],,
+  [no])
 
 dnl Setting up the apache Solr extension
 if test "$PHP_SOLR" != "no"; then


### PR DESCRIPTION
This indents the ./configure --help options and their help texts automatically.