### PR TITLE
Use AX_CHECK_COMPILE_FLAG instead of PHP_CHECK_GCC_ARG

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -64,8 +64,8 @@ if test "$PHP_SOLR" != "no"; then
     fi
 
     if test "$PHP_COVERAGE" = "yes"; then
-        PHP_CHECK_GCC_ARG(-fprofile-arcs,                     COVERAGE_CFLAGS="$COVERAGE_CFLAGS -fprofile-arcs")
-        PHP_CHECK_GCC_ARG(-ftest-coverage,                    COVERAGE_CFLAGS="$COVERAGE_CFLAGS -ftest-coverage")
+        AX_CHECK_COMPILE_FLAG([-fprofile-arcs], [COVERAGE_CFLAGS="$COVERAGE_CFLAGS -fprofile-arcs"])
+        AX_CHECK_COMPILE_FLAG([-ftest-coverage], [COVERAGE_CFLAGS="$COVERAGE_CFLAGS -ftest-coverage"])
         EXTRA_LDFLAGS="$COVERAGE_CFLAGS"
     fi
 


### PR DESCRIPTION
The PHP_CHECK_GCC_ARG M4 macro has been removed since PHP 8.0.