### PR TITLE
Fix bad return or empty string arguments in SolrUtils

### DIFF
--- a/src/php_solr_utils.c
+++ b/src/php_solr_utils.c
@@ -31,11 +31,6 @@ PHP_METHOD(SolrUtils, escapeQueryChars)
 		RETURN_FALSE;
 	}
 
-	if (!unescaped_length) {
-
-		RETURN_NULL();
-	}
-
 	memset(&sbuilder, 0, sizeof(solr_string_t));
 
 	solr_escape_query_chars(&sbuilder, unescaped, unescaped_length);
@@ -57,11 +52,6 @@ PHP_METHOD(SolrUtils, queryPhrase)
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s", &unescaped, &unescaped_length) == FAILURE) {
 
 		RETURN_FALSE;
-	}
-
-	if (!unescaped_length) {
-
-		RETURN_NULL();
 	}
 
 	memset(&sbuilder, 0, sizeof(solr_string_t));

--- a/tests/204.solrutils_empty_escapequerychars.phpt
+++ b/tests/204.solrutils_empty_escapequerychars.phpt
@@ -1,0 +1,10 @@
+--TEST--
+SolrUtils::escapeQueryChars() - Testing empty queryString
+--FILE--
+<?php
+var_dump(SolrUtils::escapeQueryChars(''));
+var_dump(SolrUtils::queryPhrase(''));
+?>
+--EXPECTF--
+string(0) ""
+string(2) """"


### PR DESCRIPTION
Fixes #83

There is no reason for returning null given an empty string. 
Plus, the methods don't actually "say" they return null, ever. 
Also, `escapeQueryChars()` actually never returns false. That will be fixed in documentation.