### PR TITLE
use zend_ce_exception instead of zend_exception_get_default() for 8.5

### DIFF
--- a/src/php_solr.h
+++ b/src/php_solr.h
@@ -126,7 +126,7 @@ extern ZEND_API zend_class_entry *zend_ce_iterator;
 #define solr_ce_Serializable zend_ce_serializable
 #define solr_ce_ArrayAccess  zend_ce_arrayaccess
 #define solr_ce_Iterator     zend_ce_iterator
-#define solr_ce_Exception    zend_exception_get_default()
+#define solr_ce_Exception    zend_ce_exception
 /* }}} */
 
 extern zend_object_handlers solr_object_handlers;


### PR DESCRIPTION
* `zend_ce_exception` available since 7.0
* `zend_exception_get_default` removed in 8.5