### PR TITLE
Add brotli and zstd checks for Windows builds

### DIFF
--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -37,7 +37,7 @@ jobs:
           php-version: ${{ matrix.php-version }}
           arch: ${{ matrix.arch }}
           ts: ${{ matrix.ts }}
-          libs: 'zlib,libxml2,libcurl,libiconv,libssh2,openssl,nghttp2'
+          libs: 'zlib,libxml2,libcurl,libiconv,libssh2,openssl,nghttp2,brotli,libzstd'
   release:
     runs-on: ubuntu-latest
     needs: build

--- a/config.w32
+++ b/config.w32
@@ -20,6 +20,13 @@ if(PHP_SOLR != 'no')
 		WARNING('solr was not enabled; nghttp2 library not found');
 		PHP_SOLR = "no";
 	}
+	if(!CHECK_LIB('brotlidec-static.lib;brotlidec.lib', 'solr', PHP_SOLR) ||
+		!CHECK_LIB('brotlicommon-static.lib;brotlicommon.lib', 'solr', PHP_SOLR)) {
+		WARNING('brotli libraries were not found; Accept-Encoding brotli may be unavailable');
+	}
+	if(!CHECK_LIB('libzstd_a.lib;libzstd.lib', 'solr', PHP_SOLR)) {
+		WARNING('zstd library not found; Accept-Encoding zstd may be unavailable');
+	}
 	if(!CHECK_LIB('crypt32.lib', 'solr', PHP_SOLR)) {
 		WARNING('solr was not enabled; crypt32 library not found');
 		PHP_SOLR = "no";


### PR DESCRIPTION
This fixes the build with recent builds of curl that has support for `brotli` and `zstd` encoding.

Ref: https://github.com/php/php-src/pull/21662