### PR TITLE
Change test outputs because of curl changes

### DIFF
--- a/tests/003.solrclient_options.phpt
+++ b/tests/003.solrclient_options.phpt
@@ -112,8 +112,8 @@ HTTP/1.1 200 OK
 Content-Type: application/xml; charset=UTF-8
 Content-Length: 0
 
-SolrClientException 1004: Solr HTTP Error 7: 'Couldn't connect to server' 
-SolrClientException 1004: Solr HTTP Error 7: 'Couldn't connect to server' 
+SolrClientException 1004: Solr HTTP Error 7: 'Could%s connect to server' 
+SolrClientException 1004: Solr HTTP Error 7: 'Could%s connect to server' 
 SolrIllegalArgumentException 4000: The SolrClient options cannot be an empty array
 
 

--- a/tests/019.solrclient_getdebug.phpt
+++ b/tests/019.solrclient_getdebug.phpt
@@ -34,6 +34,8 @@ foreach ( $lines as $line) {
 		0 === strpos($line, 'TCP_NODELAY') || 
 		0 === strpos($line, 'Accept-Encoding') ||
 		0 === strpos($line, 'Curl_http_done') ||
+		0 === strpos($line, 'Request completely sent off') ||
+		0 === strpos($line, 'using HTTP/1.x') ||
 		0 === strpos($line, 'processing:')
 		) {
 		$print = false;


### PR DESCRIPTION
When testing compilation on newer curl, some changes were needed to our tests.

In version 8.9.0 of curl, some error messages have changed. 
Two extra response headers are now also set (not sure what version).

Current version of curl for ubuntu:latest (24.04) is 8.5, 26.04 comes with 8.18.
Debian 13 ships with 8.14.